### PR TITLE
Fix "year outside of range" error getting cookies on Firefox

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -34,6 +34,9 @@ func BookMarkType(a int64) string {
 
 func TimeStampFormat(stamp int64) time.Time {
 	s1 := time.Unix(stamp, 0)
+	if s1.Local().Year() > 9999 {
+		return time.Date(9999, 12, 13, 23, 59, 59, 0, time.Local)
+	}
 	return s1
 }
 


### PR DESCRIPTION
I was unable to extract firefox cookie data. I got this error and cookies file was empty (exactly same behavior for json format):
```
cmd.go:101: error csvutil: error calling MarshalText for type time.Time: Time.MarshalText: year outside of range [0,9999]
```
This is because some web sites have to habit to set "Expires" date of cookies on `31 Dec 9999 23:59:59 GMT`, then firefox saves them (in column "expiry" of "moz_cookies" table) as timestamp of value `253402300799`.
When cookies structure is marshalled (writeToCsv and writeToJson functions) the times are converted to the local timezone and then checked and converted to csv/json.

In my partucular case (TZ is GMT+1) one hour is added to the timestamp 253402300799 and the result is `1 Jan 10000 00:59:59 +0100 CET`.  Year 10000 is outside the range, functions fail and the generated file is empty.

So if you have at least one cookie with expiry date set to `31 Dec 9999 23:59:59 GMT` and your TZ is GMT+X you can't get any cookie data. This PR is a try to fix it.
