### PR TITLE
add parse Chromium download history

### DIFF
--- a/core/browser.go
+++ b/core/browser.go
@@ -46,7 +46,7 @@ const (
 	cookie     = "cookie"
 	history    = "history"
 	bookmark   = "bookmark"
-	downloadHistory = "downloadHistory"
+	download   = "download"
 	password   = "password"
 	creditcard = "creditcard"
 )
@@ -75,9 +75,9 @@ var (
 			mainFile: data.ChromeHistoryFile,
 			newItem:  data.NewHistoryData,
 		},
-		downloadHistory: {
-			mainFile: data.ChromeHistoryFile,
-			newItem:  data.NewDownloadHistoryData,
+		download: {
+			mainFile: data.ChromeDownloadFile,
+			newItem:  data.NewDownloads,
 		},
 		password: {
 			mainFile: data.ChromePasswordFile,

--- a/core/browser.go
+++ b/core/browser.go
@@ -46,6 +46,7 @@ const (
 	cookie     = "cookie"
 	history    = "history"
 	bookmark   = "bookmark"
+	downloadHistory = "downloadHistory"
 	password   = "password"
 	creditcard = "creditcard"
 )
@@ -73,6 +74,10 @@ var (
 		history: {
 			mainFile: data.ChromeHistoryFile,
 			newItem:  data.NewHistoryData,
+		},
+		downloadHistory: {
+			mainFile: data.ChromeHistoryFile,
+			newItem:  data.NewDownloadHistoryData,
 		},
 		password: {
 			mainFile: data.ChromePasswordFile,

--- a/core/data/output.go
+++ b/core/data/output.go
@@ -42,6 +42,16 @@ func (h *historyData) outPutJson(browser, dir string) error {
 	return nil
 }
 
+func (d *downloadHistoryData) outPutJson(browser, dir string) error {
+	filename := utils.FormatFileName(dir, browser, "download_history", "json")
+	err := writeToJson(filename, d.downloadHistory)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s Get %d history, filename is %s \n", utils.Prefix, len(d.downloadHistory), filename)
+	return nil
+}
+
 func (p *passwords) outPutJson(browser, dir string) error {
 	filename := utils.FormatFileName(dir, browser, "password", "json")
 	err := writeToJson(filename, p.logins)
@@ -108,6 +118,15 @@ func (h *historyData) outPutCsv(browser, dir string) error {
 		return err
 	}
 	fmt.Printf("%s Get %d history, filename is %s \n", utils.Prefix, len(h.history), filename)
+	return nil
+}
+
+func (d *downloadHistoryData) outPutCsv(browser, dir string) error {
+	filename := utils.FormatFileName(dir, browser, "download_history", "csv")
+	if err := writeToCsv(filename, d.downloadHistory); err != nil {
+		return err
+	}
+	fmt.Printf("%s Get %d download history, filename is %s \n", utils.Prefix, len(d.downloadHistory), filename)
 	return nil
 }
 
@@ -182,6 +201,12 @@ func (c *cookies) outPutConsole() {
 
 func (h *historyData) outPutConsole() {
 	for _, v := range h.history {
+		fmt.Printf("%+v\n", v)
+	}
+}
+
+func (d *downloadHistoryData) outPutConsole() {
+	for _, v := range d.downloadHistory {
 		fmt.Printf("%+v\n", v)
 	}
 }

--- a/core/data/output.go
+++ b/core/data/output.go
@@ -42,13 +42,13 @@ func (h *historyData) outPutJson(browser, dir string) error {
 	return nil
 }
 
-func (d *downloadHistoryData) outPutJson(browser, dir string) error {
-	filename := utils.FormatFileName(dir, browser, "download_history", "json")
-	err := writeToJson(filename, d.downloadHistory)
+func (d *downloads) outPutJson(browser, dir string) error {
+	filename := utils.FormatFileName(dir, browser, "download", "json")
+	err := writeToJson(filename, d.downloads)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s Get %d history, filename is %s \n", utils.Prefix, len(d.downloadHistory), filename)
+	fmt.Printf("%s Get %d history, filename is %s \n", utils.Prefix, len(d.downloads), filename)
 	return nil
 }
 
@@ -121,12 +121,12 @@ func (h *historyData) outPutCsv(browser, dir string) error {
 	return nil
 }
 
-func (d *downloadHistoryData) outPutCsv(browser, dir string) error {
-	filename := utils.FormatFileName(dir, browser, "download_history", "csv")
-	if err := writeToCsv(filename, d.downloadHistory); err != nil {
+func (d *downloads) outPutCsv(browser, dir string) error {
+	filename := utils.FormatFileName(dir, browser, "download", "csv")
+	if err := writeToCsv(filename, d.downloads); err != nil {
 		return err
 	}
-	fmt.Printf("%s Get %d download history, filename is %s \n", utils.Prefix, len(d.downloadHistory), filename)
+	fmt.Printf("%s Get %d download history, filename is %s \n", utils.Prefix, len(d.downloads), filename)
 	return nil
 }
 
@@ -205,8 +205,8 @@ func (h *historyData) outPutConsole() {
 	}
 }
 
-func (d *downloadHistoryData) outPutConsole() {
-	for _, v := range d.downloadHistory {
+func (d *downloads) outPutConsole() {
+	for _, v := range d.downloads {
 		fmt.Printf("%+v\n", v)
 	}
 }


### PR DESCRIPTION
添加了读取 Chromium 内核浏览器 Download History 的功能。另外在此谢谢师傅写的工具，很好用。

csv 格式输出

![image](https://user-images.githubusercontent.com/25531497/107143491-52b85d80-6970-11eb-8d70-c19edc660be6.png)

![image](https://user-images.githubusercontent.com/25531497/107143535-97dc8f80-6970-11eb-881b-6f3c88dc3e44.png)

json 格式输出

![image](https://user-images.githubusercontent.com/25531497/107143648-2224f380-6971-11eb-9fac-dd019edf2b51.png)

![image](https://user-images.githubusercontent.com/25531497/107143666-3e289500-6971-11eb-8ad2-ff984c19cb55.png)

