### PR TITLE
add parse Firefox download history

### DIFF
--- a/core/browser.go
+++ b/core/browser.go
@@ -52,7 +52,7 @@ const (
 )
 
 var (
-	errItemNotSupported    = errors.New(`item not supported, default is "all", choose from history|password|bookmark|cookie`)
+	errItemNotSupported    = errors.New(`item not supported, default is "all", choose from history|download|password|bookmark|cookie`)
 	errBrowserNotSupported = errors.New("browser not supported")
 	errChromeSecretIsEmpty = errors.New("chrome secret is empty")
 	errDbusSecretIsEmpty   = errors.New("dbus secret key is empty")
@@ -104,6 +104,10 @@ var (
 		history: {
 			mainFile: data.FirefoxDataFile,
 			newItem:  data.NewHistoryData,
+		},
+		download: {
+			mainFile: data.FirefoxDataFile,
+			newItem:  data.NewDownloads,
 		},
 		password: {
 			mainFile: data.FirefoxKey4File,

--- a/core/data/parse.go
+++ b/core/data/parse.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"time"
+	"strings"
 
 	"hack-browser-data/core/decrypt"
 	"hack-browser-data/log"
@@ -55,6 +56,7 @@ var (
 	queryChromiumDownload = `SELECT target_path, tab_url, total_bytes, start_time, end_time, mime_type FROM downloads`
 	queryChromiumCookie   = `SELECT name, encrypted_value, host_key, path, creation_utc, expires_utc, is_secure, is_httponly, has_expires, is_persistent FROM cookies`
 	queryFirefoxHistory   = `SELECT id, url, last_visit_date, title, visit_count FROM moz_places`
+	queryFirefoxDownload  = `SELECT place_id, GROUP_CONCAT(content) , url, dateAdded FROM (SELECT * FROM moz_annos INNER JOIN moz_places ON moz_annos.place_id=moz_places.id) t GROUP BY place_id`
 	queryFirefoxBookMarks = `SELECT id, fk, type, dateAdded, title FROM moz_bookmarks`
 	queryFirefoxCookie    = `SELECT name, value, host, path, creationTime, expiry, isSecure, isHttpOnly FROM moz_cookies`
 	queryMetaData         = `SELECT item1, item2 FROM metaData WHERE id = 'password'`
@@ -500,9 +502,63 @@ func (d *downloads) ChromeParse(key []byte) error {
 }
 
 func (d *downloads) FirefoxParse() error {
+	var (
+		err         	error
+		keyDB       	*sql.DB
+		downloadRows	*sql.Rows
+		tempMap     	map[int64]string
+	)
+	tempMap = make(map[int64]string)
+	keyDB, err = sql.Open("sqlite3", FirefoxDataFile)
+	if err != nil {
+		return err
+	}
+	_, err = keyDB.Exec(closeJournalMode)
+	if err != nil {
+		log.Error(err)
+	}
+	defer func() {
+		if err := keyDB.Close(); err != nil {
+			log.Error(err)
+		}
+	}()
+	downloadRows, err = keyDB.Query(queryFirefoxDownload)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	defer func() {
+		if err := downloadRows.Close(); err != nil {
+			log.Error(err)
+		}
+	}()
+	for downloadRows.Next() {
+		var (
+		    content, url 		string
+			place_id, dateAdded	int64
+		)
+		err = downloadRows.Scan(&place_id, &content, &url, &dateAdded)
+		if err != nil {
+			log.Warn(err)
+		}
+		contentList := strings.Split(content, ",{")
+		if len(contentList) > 1 {
+			path := contentList[0]
+			json := "{" + contentList[1]
+			endTime := gjson.Get(json, "endTime")
+			fileSize:= gjson.Get(json, "fileSize")
+			d.downloads = append(d.downloads, download{
+				TargetPath:	path,
+				Url:		url,
+				TotalBytes: fileSize.Int(),
+				StartTime:	utils.TimeStampFormat(dateAdded / 1000000),
+				EndTime:	utils.TimeStampFormat(endTime.Int() / 1000000),
+			})
+		}
+		tempMap[place_id] = url
+	}
 	return nil
 }
-
 func (d *downloads) CopyDB() error {
 	return copyToLocalPath(d.mainPath, filepath.Base(d.mainPath))
 }

--- a/core/data/parse.go
+++ b/core/data/parse.go
@@ -491,7 +491,7 @@ func (d *downloads) ChromeParse(key []byte) error {
 			TotalBytes: totalBytes,
 			StartTime:  utils.TimeEpochFormat(startTime),
 			EndTime:    utils.TimeEpochFormat(endTime),
-			MimiType:   mimeType,
+			MimeType:   mimeType,
 		}
 		if err != nil {
 			log.Error(err)
@@ -953,7 +953,7 @@ type (
 		TotalBytes int64
 		StartTime  time.Time
 		EndTime    time.Time
-		MimiType   string
+		MimeType   string
 	}
 	card struct {
 		GUID            string

--- a/core/data/parse.go
+++ b/core/data/parse.go
@@ -552,7 +552,7 @@ func (d *downloads) FirefoxParse() error {
 				Url:		url,
 				TotalBytes: fileSize.Int(),
 				StartTime:	utils.TimeStampFormat(dateAdded / 1000000),
-				EndTime:	utils.TimeStampFormat(endTime.Int() / 1000000),
+				EndTime:	utils.TimeStampFormat(endTime.Int() / 1000),
 			})
 		}
 		tempMap[place_id] = url


### PR DESCRIPTION
添加了读取 Firefox Download History 的功能。

不过有个小问题，在 Firefox 的下载记录里没找到记录 MIME 类型 的字段。

BTW 新年快乐🎉🎉🎉

csv 格式输出

![image](https://user-images.githubusercontent.com/25531497/107617957-be117080-6c8b-11eb-9ec4-66848ac4c127.png)

![image](https://user-images.githubusercontent.com/25531497/107720546-83541a80-6d15-11eb-815e-70743175100a.png)

json 格式输出

![image](https://user-images.githubusercontent.com/25531497/107618522-a8e91180-6c8c-11eb-8bb2-3aeb2d2b3059.png)

![image](https://user-images.githubusercontent.com/25531497/107618599-c8803a00-6c8c-11eb-9fda-49807f0c46b3.png)
