### PR TITLE
Add ciphertext length check in AES decryption

### DIFF
--- a/core/decrypt/decrypt.go
+++ b/core/decrypt/decrypt.go
@@ -19,6 +19,7 @@ var (
 	errSecurityKeyIsEmpty = errors.New("input [security find-generic-password -wa 'Chrome'] in terminal")
 	errDecryptFailed      = errors.New("decrypt failed, password is empty")
 	errDecodeASN1Failed   = errors.New("decode ASN1 data failed")
+	errEncryptedLength    = errors.New("length of encrypted password less than block size")
 )
 
 type ASN1PBE interface {
@@ -164,7 +165,7 @@ func aes128CBCDecrypt(key, iv, encryptPass []byte) ([]byte, error) {
 	}
 	encryptLen := len(encryptPass)
 	if encryptLen < block.BlockSize() {
-		return nil, err
+		return nil, errEncryptedLength
 	}
 
 	dst := make([]byte, encryptLen)

--- a/core/decrypt/decrypt.go
+++ b/core/decrypt/decrypt.go
@@ -17,7 +17,6 @@ import (
 
 var (
 	errSecurityKeyIsEmpty = errors.New("input [security find-generic-password -wa 'Chrome'] in terminal")
-	errPasswordIsEmpty    = errors.New("password is empty")
 	errDecryptFailed      = errors.New("decrypt failed, password is empty")
 	errDecodeASN1Failed   = errors.New("decode ASN1 data failed")
 )
@@ -163,7 +162,12 @@ func aes128CBCDecrypt(key, iv, encryptPass []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	dst := make([]byte, len(encryptPass))
+	encryptLen := len(encryptPass)
+	if encryptLen < block.BlockSize() {
+		return nil, err
+	}
+
+	dst := make([]byte, encryptLen)
 	mode := cipher.NewCBCDecrypter(block, iv)
 	mode.CryptBlocks(dst, encryptPass)
 	dst = PKCS5UnPadding(dst)


### PR DESCRIPTION
An attempt to resolve #87 . 

Don't know how to reproduce the issue, so I'm not sure if this really address the issue. However, I believe that checking the length of `encryptPass` is necessary in AES decryption.

Also removed an unused variable.