### PR TITLE
Profile folder for Chrome and OperaGx fixed for windows

### DIFF
--- a/internal/browser/browser_windows.go
+++ b/internal/browser/browser_windows.go
@@ -4,6 +4,8 @@ package browser
 
 import (
 	"hack-browser-data/internal/item"
+	"io/ioutil"
+	"os"
 )
 
 var (
@@ -15,7 +17,7 @@ var (
 	}{
 		"chrome": {
 			name:        chromeName,
-			profilePath: chromeProfilePath,
+			profilePath: getProfiles(chromeUserDataPath)[0],
 			items:       item.DefaultChromium,
 		},
 		"edge": {
@@ -25,12 +27,12 @@ var (
 		},
 		"chromium": {
 			name:        chromiumName,
-			profilePath: chromiumProfilePath,
+			profilePath: getProfiles(chromiumUserDataPath)[0],
 			items:       item.DefaultChromium,
 		},
 		"chrome-beta": {
 			name:        chromeBetaName,
-			profilePath: chromeBetaProfilePath,
+			profilePath: getProfiles(chromeBetaUserDataPath)[0],
 			items:       item.DefaultChromium,
 		},
 		"opera": {
@@ -88,19 +90,40 @@ var (
 	}
 )
 
+func getProfiles(userDataPath string) []string {
+	var res []string
+	files, err := ioutil.ReadDir(userDataPath)
+
+	if err != nil {
+
+		res = append(res, userDataPath+"Default")
+	}
+
+	for _, f := range files {
+		if f.IsDir() && f.Name() != "System Profile" {
+			var thisPath = userDataPath + f.Name()
+			_, err := os.Stat(thisPath + "/Login Data")
+			if err == nil {
+				res = append(res, userDataPath+f.Name())
+			}
+		}
+	}
+	return res
+}
+
 var (
-	chromeProfilePath     = homeDir + "/AppData/Local/Google/Chrome/User Data/Default/"
-	chromeBetaProfilePath = homeDir + "/AppData/Local/Google/Chrome Beta/User Data/Default/"
-	chromiumProfilePath   = homeDir + "/AppData/Local/Chromium/User Data/Default/"
-	edgeProfilePath       = homeDir + "/AppData/Local/Microsoft/Edge/User Data/Default/"
-	braveProfilePath      = homeDir + "/AppData/Local/BraveSoftware/Brave-Browser/User Data/Default/"
-	speed360ProfilePath   = homeDir + "/AppData/Local/360chrome/Chrome/User Data/Default/"
-	qqBrowserProfilePath  = homeDir + "/AppData/Local/Tencent/QQBrowser/User Data/Default/"
-	operaProfilePath      = homeDir + "/AppData/Roaming/Opera Software/Opera Stable/Default/"
-	operaGXProfilePath    = homeDir + "/AppData/Roaming/Opera Software/Opera GX Stable/Default/"
-	vivaldiProfilePath    = homeDir + "/AppData/Local/Vivaldi/User Data/Default/"
-	coccocProfilePath     = homeDir + "/AppData/Local/CocCoc/Browser/User Data/Default/"
-	yandexProfilePath     = homeDir + "/AppData/Local/Yandex/YandexBrowser/User Data/Default/"
+	chromeUserDataPath     = homeDir + "/AppData/Local/Google/Chrome/User Data/"
+	chromeBetaUserDataPath = homeDir + "/AppData/Local/Google/Chrome Beta/User Data/"
+	chromiumUserDataPath   = homeDir + "/AppData/Local/Chromium/User Data/"
+	edgeProfilePath        = homeDir + "/AppData/Local/Microsoft/Edge/User Data/Default/"
+	braveProfilePath       = homeDir + "/AppData/Local/BraveSoftware/Brave-Browser/User Data/Default/"
+	speed360ProfilePath    = homeDir + "/AppData/Local/360chrome/Chrome/User Data/Default/"
+	qqBrowserProfilePath   = homeDir + "/AppData/Local/Tencent/QQBrowser/User Data/Default/"
+	operaProfilePath       = homeDir + "/AppData/Roaming/Opera Software/Opera Stable/Default/"
+	operaGXProfilePath     = homeDir + "/AppData/Roaming/Opera Software/Opera GX Stable/"
+	vivaldiProfilePath     = homeDir + "/AppData/Local/Vivaldi/User Data/Default/"
+	coccocProfilePath      = homeDir + "/AppData/Local/CocCoc/Browser/User Data/Default/"
+	yandexProfilePath      = homeDir + "/AppData/Local/Yandex/YandexBrowser/User Data/Default/"
 
 	firefoxProfilePath = homeDir + "/AppData/Roaming/Mozilla/Firefox/Profiles/"
 )


### PR DESCRIPTION
- Function `getProfiles()` has been added in `browser_windows.go` to identify the path of the Chrome profiles.

- `operaGXProfilePath` changed to `/AppData/Roaming/Opera Software/Opera GX Stable/`.

- Before: 

![Before](https://cdn.discordapp.com/attachments/861746251192336384/979374670744788992/unknown.png)

- After: 

![After](https://cdn.discordapp.com/attachments/861746251192336384/979373593286836294/unknown.png)