### PR TITLE
refactor: formatting code used to pass golangci-lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - 'deadcode'
     - 'depguard'
     - 'dogsled'
-    - 'errcheck'
     - 'errorlint'
     - 'exportloopref'
     - 'gofmt'
@@ -42,6 +41,7 @@ linters:
     - 'structcheck'
     - 'stylecheck'
     - 'unused'
+    - 'errcheck'
 
 issues:
   exclude-use-default: false
@@ -52,7 +52,9 @@ issues:
     - G101
     # G103: Use of unsafe calls should be audited
     - G103
-    # G404, G401, G502, G505 weak cryptographic list
+    # G304: Potential file inclusion via variable
+    - G304
+    # G404, G401, G502, G505: weak cryptographic list
     - G401
     - G404
     - G502

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,57 @@
+run:
+  timeout: '5m'
+  skip-dirs:
+    - 'assets'
+  allow-parallel-runners: true
+  modules-download-mode: 'readonly'
+
+linters:
+  enable:
+    - 'asciicheck'
+    - 'deadcode'
+    - 'depguard'
+    - 'dogsled'
+    - 'errcheck'
+    - 'errorlint'
+    - 'exportloopref'
+    - 'gofmt'
+    - 'gofumpt'
+    - 'goheader'
+    - 'goimports'
+    - 'gomodguard'
+    - 'goprintffuncname'
+    - 'gosec'
+    - 'govet'
+    - 'ineffassign'
+    - 'makezero'
+    - 'misspell'
+    - 'paralleltest'
+    - 'prealloc'
+    - 'predeclared'
+    - 'revive'
+    - 'typecheck'
+    - 'unconvert'
+    - 'varcheck'
+    - 'whitespace'
+  disable:
+# unsupported lint with golang 1.18+ ref: https://github.com/golangci/golangci-lint/issues/2649
+    - 'bodyclose'
+    - 'gosimple'
+    - 'noctx'
+    - 'sqlclosecheck'
+    - 'staticcheck'
+    - 'structcheck'
+    - 'stylecheck'
+    - 'unused'
+
+issues:
+  exclude-use-default: false
+  exclude:
+    - should have a package comment
+    - should have comment
+    # G103: Use of unsafe calls should be audited
+    - G103
+    # G404: Use of weak random number generator (math/rand instead of crypto/rand)
+    - G404
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,5 +59,11 @@ issues:
     - G404
     - G502
     - G505
+  exclude-rules:
+    - path: internal/browser/browser\.go
+      linters:
+        - 'deadcode'
+        - 'varcheck'
+        - 'unused'
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
     - 'errorlint'
     - 'exportloopref'
     - 'gofmt'
-    - 'gofumpt'
     - 'goheader'
     - 'goimports'
     - 'gomodguard'
@@ -49,9 +48,14 @@ issues:
   exclude:
     - should have a package comment
     - should have comment
+    # G101: Potential hardcoded credentials
+    - G101
     # G103: Use of unsafe calls should be audited
     - G103
-    # G404: Use of weak random number generator (math/rand instead of crypto/rand)
+    # G404, G401, G502, G505 weak cryptographic list
+    - G401
     - G404
+    - G502
+    - G505
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module hack-browser-data
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gocarina/gocsv v0.0.0-20211203214250-4735fba0c1d9

--- a/internal/browingdata/bookmark/bookmark.go
+++ b/internal/browingdata/bookmark/bookmark.go
@@ -6,14 +6,14 @@ import (
 	"sort"
 	"time"
 
-	"github.com/tidwall/gjson"
-
 	"hack-browser-data/internal/item"
 	"hack-browser-data/internal/log"
 	"hack-browser-data/internal/utils/fileutil"
 	"hack-browser-data/internal/utils/typeutil"
 
+	// import sqlite3 driver
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/tidwall/gjson"
 )
 
 type ChromiumBookmark []bookmark
@@ -51,7 +51,7 @@ func getBookmarkChildren(value gjson.Result, w *ChromiumBookmark) (children gjso
 	const (
 		bookmarkID       = "id"
 		bookmarkAdded    = "date_added"
-		bookmarkUrl      = "url"
+		bookmarkURL      = "url"
 		bookmarkName     = "name"
 		bookmarkType     = "type"
 		bookmarkChildren = "children"
@@ -60,7 +60,7 @@ func getBookmarkChildren(value gjson.Result, w *ChromiumBookmark) (children gjso
 	bm := bookmark{
 		ID:        value.Get(bookmarkID).Int(),
 		Name:      value.Get(bookmarkName).String(),
-		URL:       value.Get(bookmarkUrl).String(),
+		URL:       value.Get(bookmarkURL).String(),
 		DateAdded: typeutil.TimeEpoch(value.Get(bookmarkAdded).Int()),
 	}
 	children = value.Get(bookmarkChildren)

--- a/internal/browingdata/browsingdata.go
+++ b/internal/browingdata/browsingdata.go
@@ -53,17 +53,22 @@ func (d *Data) Output(dir, browserName, flag string) {
 			// if the length of the export data is 0, then it is not necessary to output
 			continue
 		}
-		filename := fileutil.Filename(browserName, source.Name(), output.Ext())
+		filename := fileutil.ItemName(browserName, source.Name(), output.Ext())
 
 		f, err := output.CreateFile(dir, filename)
 		if err != nil {
-			log.Errorf("create file error %s", err)
+			log.Errorf("create file %s error %s", filename, err.Error())
+			continue
 		}
 		if err := output.Write(source, f); err != nil {
-			log.Errorf("%s write to file %s error %s", source.Name(), filename, err.Error())
+			log.Errorf("write to file %s error %s", filename, err.Error())
+			continue
+		}
+		if err := f.Close(); err != nil {
+			log.Errorf("close file %s error %s", filename, err.Error())
+			continue
 		}
 		log.Noticef("output to file %s success", path.Join(dir, filename))
-		f.Close()
 	}
 }
 

--- a/internal/browingdata/cookie/cookie.go
+++ b/internal/browingdata/cookie/cookie.go
@@ -6,12 +6,13 @@ import (
 	"sort"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
-
 	"hack-browser-data/internal/decrypter"
 	"hack-browser-data/internal/item"
 	"hack-browser-data/internal/log"
 	"hack-browser-data/internal/utils/typeutil"
+
+	// import sqlite3 driver
+	_ "github.com/mattn/go-sqlite3"
 )
 
 type ChromiumCookie []cookie
@@ -72,7 +73,7 @@ func (c *ChromiumCookie) Parse(masterKey []byte) error {
 		if len(encryptValue) > 0 {
 			var err error
 			if masterKey == nil {
-				value, err = decrypter.DPApi(encryptValue)
+				value, err = decrypter.DPAPI(encryptValue)
 			} else {
 				value, err = decrypter.Chromium(masterKey, encryptValue)
 			}
@@ -118,10 +119,10 @@ func (f *FirefoxCookie) Parse(masterKey []byte) error {
 	for rows.Next() {
 		var (
 			name, value, host, path string
-			isSecure, isHttpOnly    int
+			isSecure, isHTTPOnly    int
 			creationTime, expiry    int64
 		)
-		if err = rows.Scan(&name, &value, &host, &path, &creationTime, &expiry, &isSecure, &isHttpOnly); err != nil {
+		if err = rows.Scan(&name, &value, &host, &path, &creationTime, &expiry, &isSecure, &isHTTPOnly); err != nil {
 			log.Warn(err)
 		}
 		*f = append(*f, cookie{
@@ -129,7 +130,7 @@ func (f *FirefoxCookie) Parse(masterKey []byte) error {
 			Host:       host,
 			Path:       path,
 			IsSecure:   typeutil.IntToBool(isSecure),
-			IsHTTPOnly: typeutil.IntToBool(isHttpOnly),
+			IsHTTPOnly: typeutil.IntToBool(isHTTPOnly),
 			CreateDate: typeutil.TimeStamp(creationTime / 1000000),
 			ExpireDate: typeutil.TimeStamp(expiry),
 			Value:      value,

--- a/internal/browingdata/creditcard/creditcard.go
+++ b/internal/browingdata/creditcard/creditcard.go
@@ -4,11 +4,12 @@ import (
 	"database/sql"
 	"os"
 
-	_ "github.com/mattn/go-sqlite3"
-
 	"hack-browser-data/internal/decrypter"
 	"hack-browser-data/internal/item"
 	"hack-browser-data/internal/log"
+
+	// import sqlite3 driver
+	_ "github.com/mattn/go-sqlite3"
 )
 
 type ChromiumCreditCard []card
@@ -56,7 +57,7 @@ func (c *ChromiumCreditCard) Parse(masterKey []byte) error {
 			NickName:        nickname,
 		}
 		if masterKey == nil {
-			value, err = decrypter.DPApi(encryptValue)
+			value, err = decrypter.DPAPI(encryptValue)
 			if err != nil {
 				return err
 			}
@@ -112,7 +113,7 @@ func (c *YandexCreditCard) Parse(masterKey []byte) error {
 			NickName:        nickname,
 		}
 		if masterKey == nil {
-			value, err = decrypter.DPApi(encryptValue)
+			value, err = decrypter.DPAPI(encryptValue)
 			if err != nil {
 				return err
 			}

--- a/internal/browingdata/download/download.go
+++ b/internal/browingdata/download/download.go
@@ -11,6 +11,7 @@ import (
 	"hack-browser-data/internal/log"
 	"hack-browser-data/internal/utils/typeutil"
 
+	// import sqlite3 driver
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/tidwall/gjson"
 )
@@ -19,7 +20,7 @@ type ChromiumDownload []download
 
 type download struct {
 	TargetPath string
-	Url        string
+	URL        string
 	TotalBytes int64
 	StartTime  time.Time
 	EndTime    time.Time
@@ -44,15 +45,15 @@ func (c *ChromiumDownload) Parse(masterKey []byte) error {
 	defer rows.Close()
 	for rows.Next() {
 		var (
-			targetPath, tabUrl, mimeType   string
+			targetPath, tabURL, mimeType   string
 			totalBytes, startTime, endTime int64
 		)
-		if err := rows.Scan(&targetPath, &tabUrl, &totalBytes, &startTime, &endTime, &mimeType); err != nil {
+		if err := rows.Scan(&targetPath, &tabURL, &totalBytes, &startTime, &endTime, &mimeType); err != nil {
 			log.Warn(err)
 		}
 		data := download{
 			TargetPath: targetPath,
-			Url:        tabUrl,
+			URL:        tabURL,
 			TotalBytes: totalBytes,
 			StartTime:  typeutil.TimeEpoch(startTime),
 			EndTime:    typeutil.TimeEpoch(endTime),
@@ -119,7 +120,7 @@ func (f *FirefoxDownload) Parse(masterKey []byte) error {
 			fileSize := gjson.Get(json, "fileSize")
 			*f = append(*f, download{
 				TargetPath: path,
-				Url:        url,
+				URL:        url,
 				TotalBytes: fileSize.Int(),
 				StartTime:  typeutil.TimeStamp(dateAdded / 1000000),
 				EndTime:    typeutil.TimeStamp(endTime.Int() / 1000),

--- a/internal/browingdata/extension/extension.go
+++ b/internal/browingdata/extension/extension.go
@@ -3,11 +3,11 @@ package extension
 import (
 	"os"
 
-	"github.com/tidwall/gjson"
-
 	"hack-browser-data/internal/item"
 	"hack-browser-data/internal/log"
 	"hack-browser-data/internal/utils/fileutil"
+
+	"github.com/tidwall/gjson"
 )
 
 type ChromiumExtension []*extension

--- a/internal/browingdata/history/history.go
+++ b/internal/browingdata/history/history.go
@@ -6,18 +6,19 @@ import (
 	"sort"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
-
 	"hack-browser-data/internal/item"
 	"hack-browser-data/internal/log"
 	"hack-browser-data/internal/utils/typeutil"
+
+	// import sqlite3 driver
+	_ "github.com/mattn/go-sqlite3"
 )
 
 type ChromiumHistory []history
 
 type history struct {
 	Title         string
-	Url           string
+	URL           string
 	VisitCount    int
 	LastVisitTime time.Time
 }
@@ -48,7 +49,7 @@ func (c *ChromiumHistory) Parse(masterKey []byte) error {
 			log.Warn(err)
 		}
 		data := history{
-			Url:           url,
+			URL:           url,
 			Title:         title,
 			VisitCount:    visitCount,
 			LastVisitTime: typeutil.TimeEpoch(lastVisitTime),
@@ -109,7 +110,7 @@ func (f *FirefoxHistory) Parse(masterKey []byte) error {
 		}
 		*f = append(*f, history{
 			Title:         title,
-			Url:           url,
+			URL:           url,
 			VisitCount:    visitCount,
 			LastVisitTime: typeutil.TimeStamp(visitDate / 1000000),
 		})

--- a/internal/browingdata/localstorage/localstorage.go
+++ b/internal/browingdata/localstorage/localstorage.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/syndtr/goleveldb/leveldb"
-
 	"hack-browser-data/internal/item"
 	"hack-browser-data/internal/log"
 	"hack-browser-data/internal/utils/typeutil"
+
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 type ChromiumLocalStorage []storage

--- a/internal/browingdata/outputter.go
+++ b/internal/browingdata/outputter.go
@@ -52,7 +52,7 @@ func (o *OutPutter) CreateFile(dir, filename string) (*os.File, error) {
 
 	if dir != "" {
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			err := os.MkdirAll(dir, 0o777)
+			err := os.MkdirAll(dir, 0o750)
 			if err != nil {
 				return nil, err
 			}
@@ -62,7 +62,7 @@ func (o *OutPutter) CreateFile(dir, filename string) (*os.File, error) {
 	var file *os.File
 	var err error
 	p := filepath.Join(dir, filename)
-	file, err = os.OpenFile(p, os.O_TRUNC|os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o666)
+	file, err = os.OpenFile(filepath.Clean(p), os.O_TRUNC|os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,6 @@ func (o *OutPutter) CreateFile(dir, filename string) (*os.File, error) {
 func (o *OutPutter) Ext() string {
 	if o.json {
 		return "json"
-	} else {
-		return "csv"
 	}
+	return "csv"
 }

--- a/internal/browingdata/outputter_test.go
+++ b/internal/browingdata/outputter_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestNewOutPutter(t *testing.T) {
+	t.Parallel()
 	out := NewOutPutter("json")
 	if out == nil {
 		t.Error("New() returned nil")

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -119,14 +119,11 @@ const (
 	chromeBetaName = "Chrome Beta"
 	chromiumName   = "Chromium"
 	edgeName       = "Microsoft Edge"
-	speed360Name   = "360speed"
-	qqBrowserName  = "QQ"
 	braveName      = "Brave"
 	operaName      = "Opera"
 	operaGXName    = "OperaGX"
 	vivaldiName    = "Vivaldi"
 	coccocName     = "CocCoc"
 	yandexName     = "Yandex"
-
-	firefoxName = "Firefox"
+	firefoxName    = "Firefox"
 )

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -114,7 +114,6 @@ func ListBrowser() []string {
 // home dir path for all platforms
 var homeDir, _ = os.UserHomeDir()
 
-//nolint:unused
 const (
 	chromeName     = "Chrome"
 	chromeBetaName = "Chrome Beta"

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -114,6 +114,7 @@ func ListBrowser() []string {
 // home dir path for all platforms
 var homeDir, _ = os.UserHomeDir()
 
+//nolint:unused
 const (
 	chromeName     = "Chrome"
 	chromeBetaName = "Chrome Beta"
@@ -126,4 +127,6 @@ const (
 	coccocName     = "CocCoc"
 	yandexName     = "Yandex"
 	firefoxName    = "Firefox"
+	speed360Name   = "360speed"
+	qqBrowserName  = "QQ"
 )

--- a/internal/browser/browser_windows.go
+++ b/internal/browser/browser_windows.go
@@ -6,6 +6,11 @@ import (
 	"hack-browser-data/internal/item"
 )
 
+const (
+	speed360Name  = "360speed"
+	qqBrowserName = "QQ"
+)
+
 var (
 	chromiumList = map[string]struct {
 		name        string

--- a/internal/browser/browser_windows.go
+++ b/internal/browser/browser_windows.go
@@ -6,11 +6,6 @@ import (
 	"hack-browser-data/internal/item"
 )
 
-const (
-	speed360Name  = "360speed"
-	qqBrowserName = "QQ"
-)
-
 var (
 	chromiumList = map[string]struct {
 		name        string

--- a/internal/browser/chromium/chromium.go
+++ b/internal/browser/chromium/chromium.go
@@ -32,7 +32,7 @@ func New(name, storage, profilePath string, items []item.Item) ([]*chromium, err
 	if err != nil {
 		return nil, err
 	}
-	var chromiumList []*chromium
+	chromiumList := make([]*chromium, 0, len(multiItemPaths))
 	for user, itemPaths := range multiItemPaths {
 		chromiumList = append(chromiumList, &chromium{
 			name:      fileutil.BrowserName(name, user),

--- a/internal/browser/chromium/chromium_darwin.go
+++ b/internal/browser/chromium/chromium_darwin.go
@@ -28,10 +28,9 @@ func (c *chromium) GetMasterKey() ([]byte, error) {
 	)
 	// don't need chromium key file for macOS
 	defer os.Remove(item.TempChromiumKey)
-	// defer os.Remove(item.TempChromiumKey)
 	// Get the master key from the keychain
 	// $ security find-generic-password -wa 'Chrome'
-	cmd = exec.Command("security", "find-generic-password", "-wa", c.storage)
+	cmd = exec.Command("security", "find-generic-password", "-wa", strings.TrimSpace(c.storage)) //nolint:gosec
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()

--- a/internal/browser/chromium/chromium_linux.go
+++ b/internal/browser/chromium/chromium_linux.go
@@ -32,7 +32,9 @@ func (c *chromium) GetMasterKey() ([]byte, error) {
 		return nil, err
 	}
 	defer func() {
-		session.Close()
+		if err := session.Close(); err != nil {
+			log.Errorf("close session failed: %v", err)
+		}
 	}()
 	collections, err := svc.GetAllCollections()
 	if err != nil {

--- a/internal/browser/chromium/chromium_windows.go
+++ b/internal/browser/chromium/chromium_windows.go
@@ -24,14 +24,14 @@ func (c *chromium) GetMasterKey() ([]byte, error) {
 	}
 	defer os.Remove(keyFile)
 	encryptedKey := gjson.Get(keyFile, "os_crypt.encrypted_key")
-	if encryptedKey.Exists() {
-		pureKey, err := base64.StdEncoding.DecodeString(encryptedKey.String())
-		if err != nil {
-			return nil, errDecodeMasterKeyFailed
-		}
-		c.masterKey, err = decrypter.DPApi(pureKey[5:])
-		log.Infof("%s initialized master key success", c.name)
-		return c.masterKey, err
+	if !encryptedKey.Exists() {
+		return nil, nil
 	}
-	return nil, nil
+	pureKey, err := base64.StdEncoding.DecodeString(encryptedKey.String())
+	if err != nil {
+		return nil, errDecodeMasterKeyFailed
+	}
+	c.masterKey, err = decrypter.DPAPI(pureKey[5:])
+	log.Infof("%s initialized master key success", c.name)
+	return c.masterKey, err
 }

--- a/internal/browser/firefox/firefox.go
+++ b/internal/browser/firefox/firefox.go
@@ -35,7 +35,8 @@ func New(name, storage, profilePath string, items []item.Item) ([]*firefox, erro
 	if err != nil {
 		return nil, err
 	}
-	var firefoxList []*firefox
+
+	firefoxList := make([]*firefox, 0, len(multiItemPaths))
 	for name, itemPaths := range multiItemPaths {
 		firefoxList = append(firefoxList, &firefox{
 			name:      fmt.Sprintf("firefox-%s", name),

--- a/internal/decrypter/decrypter.go
+++ b/internal/decrypter/decrypter.go
@@ -16,7 +16,6 @@ import (
 var (
 	errSecurityKeyIsEmpty = errors.New("input [security find-generic-password -wa 'Chrome'] in terminal")
 	errPasswordIsEmpty    = errors.New("password is empty")
-	errDecryptFailed      = errors.New("decrypt encrypted value failed")
 	errDecodeASN1Failed   = errors.New("decode ASN1 data failed")
 	errEncryptedLength    = errors.New("length of encrypted password less than block size")
 )

--- a/internal/decrypter/decrypter.go
+++ b/internal/decrypter/decrypter.go
@@ -185,6 +185,7 @@ func (l loginPBE) Decrypt(globalSalt, masterPwd []byte) (key []byte, err error) 
 func (l loginPBE) iv() []byte {
 	return l.Data.IV
 }
+
 func (l loginPBE) encrypted() []byte {
 	return l.Encrypted
 }

--- a/internal/decrypter/decrypter.go
+++ b/internal/decrypter/decrypter.go
@@ -14,10 +14,9 @@ import (
 )
 
 var (
-	errSecurityKeyIsEmpty = errors.New("input [security find-generic-password -wa 'Chrome'] in terminal")
-	errPasswordIsEmpty    = errors.New("password is empty")
-	errDecodeASN1Failed   = errors.New("decode ASN1 data failed")
-	errEncryptedLength    = errors.New("length of encrypted password less than block size")
+	errPasswordIsEmpty  = errors.New("password is empty")
+	errDecodeASN1Failed = errors.New("decode ASN1 data failed")
+	errEncryptedLength  = errors.New("length of encrypted password less than block size")
 )
 
 type ASN1PBE interface {

--- a/internal/decrypter/decrypter_darwin.go
+++ b/internal/decrypter/decrypter_darwin.go
@@ -1,17 +1,17 @@
 package decrypter
 
 func Chromium(key, encryptPass []byte) ([]byte, error) {
-	if len(encryptPass) > 3 {
-		if len(key) == 0 {
-			return nil, errSecurityKeyIsEmpty
-		}
-		chromeIV := []byte{32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32}
-		return aes128CBCDecrypt(key, chromeIV, encryptPass[3:])
-	} else {
-		return nil, errDecryptFailed
+	if len(encryptPass) <= 3 {
+		return nil, errPasswordIsEmpty
 	}
+	if len(key) == 0 {
+		return nil, errSecurityKeyIsEmpty
+	}
+
+	iv := []byte{32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32}
+	return aes128CBCDecrypt(key, iv, encryptPass[3:])
 }
 
-func DPApi(data []byte) ([]byte, error) {
+func DPAPI(data []byte) ([]byte, error) {
 	return nil, nil
 }

--- a/internal/decrypter/decrypter_darwin.go
+++ b/internal/decrypter/decrypter_darwin.go
@@ -1,5 +1,9 @@
 package decrypter
 
+var (
+	errSecurityKeyIsEmpty = errors.New("input [security find-generic-password -wa 'Chrome'] in terminal")
+)
+
 func Chromium(key, encryptPass []byte) ([]byte, error) {
 	if len(encryptPass) <= 3 {
 		return nil, errPasswordIsEmpty

--- a/internal/decrypter/decrypter_linux.go
+++ b/internal/decrypter/decrypter_linux.go
@@ -1,17 +1,17 @@
 package decrypter
 
 func Chromium(key, encryptPass []byte) ([]byte, error) {
-	chromeIV := []byte{32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32}
-	if len(encryptPass) > 3 {
-		if len(key) == 0 {
-			return nil, errSecurityKeyIsEmpty
-		}
-		return aes128CBCDecrypt(key, chromeIV, encryptPass[3:])
-	} else {
-		return nil, errDecryptFailed
+	if len(encryptPass) < 3 {
+		return nil, errPasswordIsEmpty
 	}
+	if len(key) == 0 {
+		return nil, errSecurityKeyIsEmpty
+	}
+
+	chromeIV := []byte{32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32}
+	return aes128CBCDecrypt(key, chromeIV, encryptPass[3:])
 }
 
-func DPApi(data []byte) ([]byte, error) {
+func DPAPI(data []byte) ([]byte, error) {
 	return nil, nil
 }

--- a/internal/decrypter/decrypter_linux.go
+++ b/internal/decrypter/decrypter_linux.go
@@ -4,9 +4,6 @@ func Chromium(key, encryptPass []byte) ([]byte, error) {
 	if len(encryptPass) < 3 {
 		return nil, errPasswordIsEmpty
 	}
-	if len(key) == 0 {
-		return nil, errSecurityKeyIsEmpty
-	}
 
 	chromeIV := []byte{32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32}
 	return aes128CBCDecrypt(key, chromeIV, encryptPass[3:])

--- a/internal/decrypter/decrypter_windows.go
+++ b/internal/decrypter/decrypter_windows.go
@@ -8,25 +8,29 @@ import (
 )
 
 func Chromium(key, encryptPass []byte) ([]byte, error) {
-	if len(encryptPass) > 15 {
-		// remove Prefix 'v10'
-		return aesGCMDecrypt(encryptPass[15:], key, encryptPass[3:15])
-	} else {
+	if len(encryptPass) < 3 {
 		return nil, errPasswordIsEmpty
 	}
+	if len(key) == 0 {
+		return nil, errSecurityKeyIsEmpty
+	}
+
+	return aesGCMDecrypt(encryptPass[15:], key, encryptPass[3:15])
 }
 
 func ChromiumForYandex(key, encryptPass []byte) ([]byte, error) {
-	if len(encryptPass) > 15 {
-		// remove Prefix 'v10'
-		// gcmBlockSize         = 16
-		// gcmTagSize           = 16
-		// gcmMinimumTagSize    = 12 // NIST SP 800-38D recommends tags with 12 or more bytes.
-		// gcmStandardNonceSize = 12
-		return aesGCMDecrypt(encryptPass[12:], key, encryptPass[0:12])
-	} else {
+	if len(encryptPass) < 3 {
 		return nil, errPasswordIsEmpty
 	}
+	if len(key) == 0 {
+		return nil, errSecurityKeyIsEmpty
+	}
+	// remove Prefix 'v10'
+	// gcmBlockSize         = 16
+	// gcmTagSize           = 16
+	// gcmMinimumTagSize    = 12 // NIST SP 800-38D recommends tags with 12 or more bytes.
+	// gcmStandardNonceSize = 12
+	return aesGCMDecrypt(encryptPass[12:], key, encryptPass[0:12])
 }
 
 // chromium > 80 https://source.chromium.org/chromium/chromium/src/+/master:components/os_crypt/os_crypt_win.cc
@@ -67,9 +71,12 @@ func (b *dataBlob) ToByteArray() []byte {
 	return d
 }
 
-// DPApi
+// DPAPI (Data Protection Application Programming Interface)
+// is a simple cryptographic application programming interface
+// available as a built-in component in Windows 2000 and
+// later versions of Microsoft Windows operating systems
 // chrome < 80 https://chromium.googlesource.com/chromium/src/+/76f496a7235c3432983421402951d73905c8be96/components/os_crypt/os_crypt_win.cc#82
-func DPApi(data []byte) ([]byte, error) {
+func DPAPI(data []byte) ([]byte, error) {
 	dllCrypt := syscall.NewLazyDLL("Crypt32.dll")
 	dllKernel := syscall.NewLazyDLL("Kernel32.dll")
 	procDecryptData := dllCrypt.NewProc("CryptUnprotectData")

--- a/internal/utils/typeutil/typeutil_test.go
+++ b/internal/utils/typeutil/typeutil_test.go
@@ -4,13 +4,15 @@ import (
 	"testing"
 )
 
-var reverseTestCases = [][]any{
-	{1, 2, 3, 4, 5},
-	{"1", "2", "3", "4", "5"},
-	{"1", 2, "3", "4", 5},
-}
-
 func TestReverse(t *testing.T) {
+	t.Parallel()
+
+	reverseTestCases := [][]any{
+		{1, 2, 3, 4, 5},
+		{"1", "2", "3", "4", "5"},
+		{"1", 2, "3", "4", 5},
+	}
+
 	for _, ts := range reverseTestCases {
 		h := Reverse(ts)
 		for i := 0; i < len(ts); i++ {


### PR DESCRIPTION
add those linters
``` yml
linters:
  enable:
    - 'asciicheck'
    - 'deadcode'
    - 'depguard'
    - 'dogsled'
    - 'errorlint'
    - 'exportloopref'
    - 'gofmt'
    - 'goheader'
    - 'goimports'
    - 'gomodguard'
    - 'goprintffuncname'
    - 'gosec'
    - 'govet'
    - 'ineffassign'
    - 'makezero'
    - 'misspell'
    - 'paralleltest'
    - 'prealloc'
    - 'predeclared'
    - 'revive'
    - 'typecheck'
    - 'unconvert'
    - 'varcheck'
    - 'whitespace'
```
also exclude some rulers
``` yml
issues:
  exclude-use-default: false
  exclude:
    - should have a package comment
    - should have comment
    # G101: Potential hardcoded credentials
    - G101
    # G103: Use of unsafe calls should be audited
    - G103
    # G304: Potential file inclusion via variable
    - G304
    # G404, G401, G502, G505: weak cryptographic list
    - G401
    - G404
    - G502
    - G505
  exclude-rules:
    - path: internal/browser/browser\.go
      linters:
        - 'deadcode'
        - 'varcheck'
        - 'unused'
```