### PR TITLE
fix: issue of data missing caused by title being null

### DIFF
--- a/internal/browingdata/history/history.go
+++ b/internal/browingdata/history/history.go
@@ -73,7 +73,7 @@ func (c *ChromiumHistory) Length() int {
 type FirefoxHistory []history
 
 const (
-	queryFirefoxHistory = `SELECT id, url, last_visit_date, title, visit_count FROM moz_places where title not null`
+	queryFirefoxHistory = `SELECT id, url, COALESCE(last_visit_date, 0), COALESCE(title, ''), visit_count FROM moz_places`
 	closeJournalMode    = `PRAGMA journal_mode=off`
 )
 


### PR DESCRIPTION
If the null title is filtered out, a lot of browsing records will be missing. The COALESCE function fix this issue. At the same time, COALESCE function also helps solving the warning caused by _last_visit_date_ being null.