### PR TITLE
fix: the bug that the command line Usage prompt is incomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You can double-click to run, or use command line.
 ```
 PS C:\test> .\hack-browser-data.exe -h
 NAME:
-   hack-browser-data - Export passwords/cookies/history/bookmarks from browser
+   hack-browser-data - Export password|bookmark|cookie|history|credit card|download|localStorage|extension from browser
 
 USAGE:
    [hack-browser-data -b chrome -f json -dir results -cc]

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -121,7 +121,7 @@ CC=x86_64-linux-musl-gcc CXX=x86_64-linux-musl-g++ GOARCH=amd64 GOOS=linux CGO_E
 ```
 PS C:\test> .\hack-browser-data.exe -h
 NAME:
-   hack-browser-data - Export passwords/cookies/history/bookmarks from browser
+   hack-browser-data - Export password|bookmark|cookie|history|credit card|download|localStorage|extension from browser
 
 USAGE:
    [hack-browser-data -b chrome -f json -dir results -cc]

--- a/cmd/hack-browser-data/main.go
+++ b/cmd/hack-browser-data/main.go
@@ -27,7 +27,7 @@ func main() {
 func Execute() {
 	app := &cli.App{
 		Name:      "hack-browser-data",
-		Usage:     "Export passwords/cookies/history/bookmarks from browser",
+		Usage:     "Export password|bookmark|cookie|history|credit card|download|localStorage|extension from browser",
 		UsageText: "[hack-browser-data -b chrome -f json -dir results -cc]\nExport all browingdata(password/cookie/history/bookmark) from browser\nGithub Link: https://github.com/moonD4rk/HackBrowserData",
 		Version:   "0.4.4",
 		Flags: []cli.Flag{


### PR DESCRIPTION
The full prompt is "password|bookmark|cookie|history|credit card|download|localStorage|extension"

Signed-off-by: yuxiaojun <yuxiaojun@uniontech.com>