### PR TITLE
fix: renaming unused parameter

### DIFF
--- a/browingdata/bookmark/bookmark.go
+++ b/browingdata/bookmark/bookmark.go
@@ -26,7 +26,7 @@ type bookmark struct {
 	DateAdded time.Time
 }
 
-func (c *ChromiumBookmark) Parse(masterKey []byte) error {
+func (c *ChromiumBookmark) Parse(_ []byte) error {
 	bookmarks, err := fileutil.ReadFile(item.TempChromiumBookmark)
 	if err != nil {
 		return err
@@ -93,7 +93,7 @@ const (
 	closeJournalMode     = `PRAGMA journal_mode=off`
 )
 
-func (f *FirefoxBookmark) Parse(masterKey []byte) error {
+func (f *FirefoxBookmark) Parse(_ []byte) error {
 	db, err := sql.Open("sqlite3", item.TempFirefoxBookmark)
 	if err != nil {
 		return err

--- a/browingdata/cookie/cookie.go
+++ b/browingdata/cookie/cookie.go
@@ -103,7 +103,7 @@ const (
 	queryFirefoxCookie = `SELECT name, value, host, path, creationTime, expiry, isSecure, isHttpOnly FROM moz_cookies`
 )
 
-func (f *FirefoxCookie) Parse(masterKey []byte) error {
+func (f *FirefoxCookie) Parse(_ []byte) error {
 	db, err := sql.Open("sqlite3", item.TempFirefoxCookie)
 	if err != nil {
 		return err

--- a/browingdata/download/download.go
+++ b/browingdata/download/download.go
@@ -31,7 +31,7 @@ const (
 	queryChromiumDownload = `SELECT target_path, tab_url, total_bytes, start_time, end_time, mime_type FROM downloads`
 )
 
-func (c *ChromiumDownload) Parse(masterKey []byte) error {
+func (c *ChromiumDownload) Parse(_ []byte) error {
 	db, err := sql.Open("sqlite3", item.TempChromiumDownload)
 	if err != nil {
 		return err
@@ -82,7 +82,7 @@ const (
 	closeJournalMode     = `PRAGMA journal_mode=off`
 )
 
-func (f *FirefoxDownload) Parse(masterKey []byte) error {
+func (f *FirefoxDownload) Parse(_ []byte) error {
 	db, err := sql.Open("sqlite3", item.TempFirefoxDownload)
 	if err != nil {
 		return err

--- a/browingdata/extension/extension.go
+++ b/browingdata/extension/extension.go
@@ -23,7 +23,7 @@ const (
 	manifest = "manifest.json"
 )
 
-func (c *ChromiumExtension) Parse(masterKey []byte) error {
+func (c *ChromiumExtension) Parse(_ []byte) error {
 	files, err := fileutil.FilesInFolder(item.TempChromiumExtension, manifest)
 	if err != nil {
 		return err
@@ -56,7 +56,7 @@ func (c *ChromiumExtension) Len() int {
 
 type FirefoxExtension []*extension
 
-func (f *FirefoxExtension) Parse(masterKey []byte) error {
+func (f *FirefoxExtension) Parse(_ []byte) error {
 	s, err := fileutil.ReadFile(item.TempFirefoxExtension)
 	if err != nil {
 		return err

--- a/browingdata/history/history.go
+++ b/browingdata/history/history.go
@@ -27,7 +27,7 @@ const (
 	queryChromiumHistory = `SELECT url, title, visit_count, last_visit_time FROM urls`
 )
 
-func (c *ChromiumHistory) Parse(masterKey []byte) error {
+func (c *ChromiumHistory) Parse(_ []byte) error {
 	db, err := sql.Open("sqlite3", item.TempChromiumHistory)
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ const (
 	closeJournalMode    = `PRAGMA journal_mode=off`
 )
 
-func (f *FirefoxHistory) Parse(masterKey []byte) error {
+func (f *FirefoxHistory) Parse(_ []byte) error {
 	db, err := sql.Open("sqlite3", item.TempFirefoxHistory)
 	if err != nil {
 		return err

--- a/browingdata/localstorage/localstorage.go
+++ b/browingdata/localstorage/localstorage.go
@@ -28,7 +28,7 @@ type storage struct {
 
 const maxLocalStorageValueLength = 1024 * 2
 
-func (c *ChromiumLocalStorage) Parse(masterKey []byte) error {
+func (c *ChromiumLocalStorage) Parse(_ []byte) error {
 	db, err := leveldb.OpenFile(item.TempChromiumLocalStorage, nil)
 	if err != nil {
 		return err
@@ -105,7 +105,7 @@ const (
 	closeJournalMode    = `PRAGMA journal_mode=off`
 )
 
-func (f *FirefoxLocalStorage) Parse(masterKey []byte) error {
+func (f *FirefoxLocalStorage) Parse(_ []byte) error {
 	db, err := sql.Open("sqlite3", item.TempFirefoxLocalStorage)
 	if err != nil {
 		return err

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -134,7 +134,7 @@ type slatAttr struct {
 	}
 }
 
-func (m metaPBE) Decrypt(globalSalt, masterPwd []byte) (key2 []byte, err error) {
+func (m metaPBE) Decrypt(globalSalt, _ []byte) (key2 []byte, err error) {
 	k := sha1.Sum(globalSalt)
 	key := pbkdf2.Key(k[:], m.salt(), m.iterationCount(), m.keySize(), sha256.New)
 	iv := append([]byte{4, 14}, m.iv()...)
@@ -177,7 +177,7 @@ type loginPBE struct {
 	Encrypted []byte
 }
 
-func (l loginPBE) Decrypt(globalSalt, masterPwd []byte) (key []byte, err error) {
+func (l loginPBE) Decrypt(globalSalt, _ []byte) (key []byte, err error) {
 	return des3Decrypt(globalSalt, l.iv(), l.encrypted())
 }
 

--- a/crypto/crypto_darwin.go
+++ b/crypto/crypto_darwin.go
@@ -11,6 +11,6 @@ func DecryptPass(key, encryptPass []byte) ([]byte, error) {
 	return aes128CBCDecrypt(key, iv, encryptPass[3:])
 }
 
-func DPAPI(data []byte) ([]byte, error) {
+func DPAPI(_ []byte) ([]byte, error) {
 	return nil, nil
 }

--- a/crypto/crypto_linux.go
+++ b/crypto/crypto_linux.go
@@ -11,6 +11,6 @@ func DecryptPass(key, encryptPass []byte) ([]byte, error) {
 	return aes128CBCDecrypt(key, iv, encryptPass[3:])
 }
 
-func DPAPI(data []byte) ([]byte, error) {
+func DPAPI(_ []byte) ([]byte, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Fix `revive` lint.

Renaming `masterKey` as `_`.