### PR TITLE
Replace the combination of os. ReadFile() and os. WriteFile() with io. Copy()

### DIFF
--- a/utils/fileutil/filetutil.go
+++ b/utils/fileutil/filetutil.go
@@ -96,15 +96,26 @@ func CopyDirHasSuffix(src, dst, suffix string) error {
 
 // CopyFile copies the file from the source to the destination
 func CopyFile(src, dst string) error {
-	s, err := os.ReadFile(src)
-	if err != nil {
-		return err
-	}
-	err = os.WriteFile(dst, s, 0o600)
-	if err != nil {
-		return err
-	}
-	return nil
+    fsrc, err := os.Open(src)
+    if err != nil {
+        return err
+    }
+    defer fsrc.Close()
+
+    fdst, err := os.Create(dst)
+    if err != nil {
+        return err
+    }
+    defer fdst.Close()
+
+    if _, err := io.Copy(fdst, fsrc); err != nil {
+        return err
+    }
+
+    if err := fdst.Sync(); err != nil {
+        return err
+    }
+    return nil
 }
 
 // ItemName returns the filename from the provided path

--- a/utils/fileutil/filetutil.go
+++ b/utils/fileutil/filetutil.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"


### PR DESCRIPTION
…. Copy()

Use io. Copy() instead of the combination of os. ReadFile() and os. WriteFile() to avoid reading the entire file into memory and writing it back to disk. This can reduce memory usage and improve efficiency