### PR TITLE
fix nil browsing data in case error

### DIFF
--- a/cmd/hack-browser-data/main.go
+++ b/cmd/hack-browser-data/main.go
@@ -53,6 +53,7 @@ func Execute() {
 				data, err := b.BrowsingData(isFullExport)
 				if err != nil {
 					log.Error(err)
+					continue
 				}
 				data.Output(outputDir, b.Name(), outputFormat)
 			}


### PR DESCRIPTION
in case there is an error with browsing data, error will be just logged. which causes panic because of browsing data will be `nil` and then one of its fields will be accessed https://github.com/moonD4rk/HackBrowserData/blob/master/browingdata/browsingdata.go#L52