### PR TITLE
fix: Bug fixes in firefox file walk

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -87,11 +87,13 @@ func pickFirefox(name, profile string) []Browser {
 			} else {
 				profile = fileutil.ParentDir(profile)
 			}
+
 			if !fileutil.IsDirExists(filepath.Clean(profile)) {
 				log.Noticef("find browser firefox %s failed, profile folder does not exist", v.name)
 				continue
 			}
-			if multiFirefox, err := firefox.New(v.name, v.storage, profile, v.items); err == nil {
+
+			if multiFirefox, err := firefox.New(profile, v.items); err == nil {
 				for _, b := range multiFirefox {
 					log.Noticef("find browser firefox %s success", b.Name())
 					browsers = append(browsers, b)
@@ -100,8 +102,10 @@ func pickFirefox(name, profile string) []Browser {
 				log.Error(err)
 			}
 		}
+
 		return browsers
 	}
+
 	return nil
 }
 

--- a/cmd/hack-browser-data/main.go
+++ b/cmd/hack-browser-data/main.go
@@ -53,6 +53,7 @@ func Execute() {
 				data, err := b.BrowsingData(isFullExport)
 				if err != nil {
 					log.Error(err)
+					continue
 				}
 				data.Output(outputDir, b.Name(), outputFormat)
 			}


### PR DESCRIPTION
- fix panic in case browser data error
- ignore files walk error in firefox, since it will be returned if at least one invocation of file walk function returns error
- use `WalkDir` instead of `Walk` since its faster
- simplify logic a bit in firefox browser init