### PR TITLE
fix: warn if failed to decrypt master key

### DIFF
--- a/browser/chromium/chromium_windows.go
+++ b/browser/chromium/chromium_windows.go
@@ -34,6 +34,10 @@ func (c *Chromium) GetMasterKey() ([]byte, error) {
 		return nil, errDecodeMasterKeyFailed
 	}
 	c.masterKey, err = crypto.DPAPI(key[5:])
+	if err != nil {
+		log.Errorf("%s failed to decrypt master key, maybe this profile was created on a different OS installation", c.name)
+		return nil, err
+	}
 	log.Infof("%s initialized master key success", c.name)
-	return c.masterKey, err
+	return c.masterKey, nil
 }


### PR DESCRIPTION
解密重装系统前的数据失败时，增加报错信息。

---

我本来是想重构一下，让 Master Key 解密失败时也能导出无需解密的数据，不过重构到一半看到你在 24c90f5b92a356631c5ea14ecff1f05eac7903dd ([feat/library](https://github.com/moonD4rk/HackBrowserData/commits/feat/library)) 也有重构计划，所以就不弄了，我改到一半的结果在 e6230418341a6de7d44233768f8afdf127ed09d1 ([分支](https://github.com/stevenlele/HackBrowserData/tree/refactor))，修改点如下：
- 目前 Browser 的 Chromium/Firefox 多态没什么意义，本来 pickXxx 就是分开的，各个数据项也是分开解析的，所以重构去掉了
- 把临时文件复制移动到各个数据 parsing 里面，这样就不会留下临时数据；部分没必要复制的就不再复制了
- 把 Yandex 逻辑合并到 Chromium 里面，减少重复代码
- 重构不是很彻底，比如可以弄一个 BrowserType 的枚举写进 Browser 里面（看到你弄了），这样更稳健

代码就留着供参考，如果你觉得哪些做法不合适可以指正讨论一下，或者直接无视就好。


