### PR TITLE
refactor: optimize JSON indent output format

### DIFF
--- a/browsingdata/outputter.go
+++ b/browsingdata/outputter.go
@@ -32,7 +32,7 @@ func (o *outPutter) Write(data Source, writer io.Writer) error {
 	switch o.json {
 	case true:
 		encoder := json.NewEncoder(writer)
-		encoder.SetIndent("  ", "  ")
+		encoder.SetIndent("", "  ")
 		encoder.SetEscapeHTML(false)
 		return encoder.Encode(data)
 	default:


### PR DESCRIPTION
Remove space in json output.
Before
```json
[
   {
     "Name": "name1",
     "Password": "password1",
     "Infos": [
       {
         "Infos1": "Infos1",
         "Infos2": "Infos2",
         "Infos3": 1
       }
     ]
   },
   {
     "Name": "name2",
     "Password": "password2",
     "Infos": [
       {
         "Infos1": "Infos1",
         "Infos2": "",
         "Infos3": 1
       }
     ]
   }
 ]
```
After:
```json
[
  {
    "Name": "name1",
    "Password": "password1",
    "Infos": [
      {
        "Infos1": "Infos1",
        "Infos2": "Infos2",
        "Infos3": 1
      }
    ]
  },
  {
    "Name": "name2",
    "Password": "password2",
    "Infos": [
      {
        "Infos1": "Infos1",
        "Infos2": "",
        "Infos3": 1
      }
    ]
  }
]
```
