### PR TITLE
fix: Improve error handling in browsing data and file copying functions

### DIFF
--- a/browser/chromium/chromium.go
+++ b/browser/chromium/chromium.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/moond4rk/hackbrowserdata/browsingdata"
 	"github.com/moond4rk/hackbrowserdata/item"
+	"github.com/moond4rk/hackbrowserdata/log"
 	"github.com/moond4rk/hackbrowserdata/utils/fileutil"
 	"github.com/moond4rk/hackbrowserdata/utils/typeutil"
 )
@@ -89,7 +90,8 @@ func (c *Chromium) copyItemToLocal() error {
 			err = fileutil.CopyFile(path, filename)
 		}
 		if err != nil {
-			return err
+			log.Errorf("copy %s to %s error: %v", path, filename, err)
+			continue
 		}
 	}
 	return nil

--- a/browsingdata/browsingdata.go
+++ b/browsingdata/browsingdata.go
@@ -41,6 +41,7 @@ func (d *Data) Recovery(masterKey []byte) error {
 	for _, source := range d.sources {
 		if err := source.Parse(masterKey); err != nil {
 			log.Errorf("parse %s error %s", source.Name(), err.Error())
+			continue
 		}
 	}
 	return nil


### PR DESCRIPTION
Fix the bug that causes the program to unexpectedly exit when unable to open a file for copying. 

This error mainly occurs when the database file is being used by another process, especially in the case of files storing cookies. 

Currently, only skipping the error is possible; other methods are required for a complete fix.

Close
- https://github.com/moonD4rk/HackBrowserData/issues/255
- https://github.com/moonD4rk/HackBrowserData/issues/233
- https://github.com/moonD4rk/HackBrowserData/issues/222

Ref
- https://github.com/moonD4rk/HackBrowserData/issues/243 