### PR TITLE
ci: Update default branch references in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 jobs:
   build:

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 1 * * 0' # At 01:00 on Sunday.
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,8 @@ name: Lint
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
-  
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
- Update Github Actions workflows to use `main` branch instead of `master`.
- Rename `master` branch to `main` in `lint.yml` and `build.yml` files.
- Change default branch to `main` in `contributors.yml` workflow file.
- Close #270 