### PR TITLE
fix: Improve error handling if walk browser profile dir

### DIFF
--- a/browser/firefox/firefox.go
+++ b/browser/firefox/firefox.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -59,6 +60,13 @@ func (f *Firefox) copyItemToLocal() error {
 
 func firefoxWalkFunc(items []types.DataType, multiItemPaths map[string]map[types.DataType]string) fs.WalkDirFunc {
 	return func(path string, info fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsPermission(err) {
+				slog.Warn("skipping walk firefox path permission error", "path", path, "err", err)
+				return nil
+			}
+			return err
+		}
 		for _, v := range items {
 			if info.Name() == v.Filename() {
 				parentBaseDir := fileutil.ParentBaseDir(path)
@@ -70,7 +78,7 @@ func firefoxWalkFunc(items []types.DataType, multiItemPaths map[string]map[types
 			}
 		}
 
-		return err
+		return nil
 	}
 }
 


### PR DESCRIPTION
- Implement error handling for path permission errors in `chromiumWalkFunc`
- Refactor `firefoxWalkFunc` to handle permission errors and log warnings
- Add import statement for `log/slog` in `firefox/firefox.go`

## Proposed changes

<!-- Describe the overall picture of your modifications to help maintainers understand the pull request. PRs are required to be associated to their related issue tickets or feature request. -->
If access to the browser configuration file is not permitted, print an error log and skip.

Close https://github.com/moonD4rk/HackBrowserData/issues/345

## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Pull request is created against the [dev](https://github.com/moonD4rk/HackBrowserData/tree/dev) branch
- [x] All checks passed (lint, unit, build tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)