### PR TITLE
fix: skip chromium-based browser 'def' dir

### DIFF
--- a/browser/chromium/chromium.go
+++ b/browser/chromium/chromium.go
@@ -156,6 +156,9 @@ func chromiumWalkFunc(items []types.DataType, multiItemPaths map[string]map[type
 			if strings.Contains(path, "Snapshot") {
 				continue
 			}
+			if strings.Contains(path, "def") {
+				continue
+			}
 			profileFolder := fileutil.ParentBaseDir(path)
 			if strings.Contains(filepath.ToSlash(path), "/Network/Cookies") {
 				profileFolder = fileutil.BaseDir(strings.ReplaceAll(filepath.ToSlash(path), "/Network/Cookies", ""))


### PR DESCRIPTION
## Proposed changes

fix [Chromium-based browsers find wrong user](https://github.com/moonD4rk/HackBrowserData/issues/447)


## Checklist

- [x] Pull request is created against the [dev](https://github.com/moonD4rk/HackBrowserData/tree/dev) branch
- [x] All checks passed (lint, unit, build tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)