### PR TITLE
fix cookie and password decryption for macOS

### DIFF
--- a/browser/browser_windows.go
+++ b/browser/browser_windows.go
@@ -63,9 +63,14 @@ var (
 			profilePath: yandexProfilePath,
 			dataTypes:   types.DefaultYandexTypes,
 		},
-		"360": {
+		"360-speed": {
 			name:        speed360Name,
 			profilePath: speed360ProfilePath,
+			dataTypes:   types.DefaultChromiumTypes,
+		},
+		"360-speedx": {
+			name:        speedX360Name,
+			profilePath: speedX360ProfilePath,
 			dataTypes:   types.DefaultChromiumTypes,
 		},
 		"qq": {
@@ -105,6 +110,7 @@ var (
 	edgeProfilePath        = homeDir + "/AppData/Local/Microsoft/Edge/User Data/Default/"
 	braveProfilePath       = homeDir + "/AppData/Local/BraveSoftware/Brave-Browser/User Data/Default/"
 	speed360ProfilePath    = homeDir + "/AppData/Local/360chrome/Chrome/User Data/Default/"
+	speedX360ProfilePath   = homeDir + "/AppData/Local/360ChromeX/Chrome/User Data/Default/"
 	qqBrowserProfilePath   = homeDir + "/AppData/Local/Tencent/QQBrowser/User Data/Default/"
 	operaProfilePath       = homeDir + "/AppData/Roaming/Opera Software/Opera Stable/"
 	operaGXProfilePath     = homeDir + "/AppData/Roaming/Opera Software/Opera GX Stable/"
@@ -112,7 +118,7 @@ var (
 	coccocProfilePath      = homeDir + "/AppData/Local/CocCoc/Browser/User Data/Default/"
 	yandexProfilePath      = homeDir + "/AppData/Local/Yandex/YandexBrowser/User Data/Default/"
 	dcBrowserProfilePath   = homeDir + "/AppData/Local/DCBrowser/User Data/Default/"
-	sogouProfilePath       = homeDir + "/AppData/Roaming/SogouExplorer/Webkit/Default/"
+	sogouProfilePath       = homeDir + "/AppData/Local/Sogou/SogouExplorer/User Data/Default/"
 
 	firefoxProfilePath = homeDir + "/AppData/Roaming/Mozilla/Firefox/Profiles/"
 )

--- a/browser/consts.go
+++ b/browser/consts.go
@@ -20,6 +20,7 @@ const (
 	yandexName     = "Yandex"
 	firefoxName    = "Firefox"
 	speed360Name   = "360speed"
+	speedX360Name  = "360speedX"
 	qqBrowserName  = "QQ"
 	dcBrowserName  = "DC"
 	sogouName      = "Sogou"

--- a/browserdata/cookie/cookie.go
+++ b/browserdata/cookie/cookie.go
@@ -87,10 +87,12 @@ func (c *ChromiumCookie) Extract(masterKey []byte) error {
 				value, err = crypto.DecryptWithChromium(masterKey, encryptValue)
 				if err != nil {
 					log.Debugf("decrypt chromium cookie error: %v", err)
+				} else if len(value) > 32 {
+					// https://gist.github.com/kosh04/36cf6023fb75b516451ce933b9db2207?permalink_comment_id=5291243#gistcomment-5291243
+					value = value[32:]
 				}
 			}
 		}
-
 		cookie.Value = string(value)
 		*c = append(*c, cookie)
 	}

--- a/crypto/crypto_darwin.go
+++ b/crypto/crypto_darwin.go
@@ -2,6 +2,10 @@
 
 package crypto
 
+import "errors"
+
+var ErrDarwinNotSupportDPAPI = errors.New("darwin not support dpapi")
+
 func DecryptWithChromium(key, password []byte) ([]byte, error) {
 	if len(password) <= 3 {
 		return nil, ErrCiphertextLengthIsInvalid
@@ -11,5 +15,5 @@ func DecryptWithChromium(key, password []byte) ([]byte, error) {
 }
 
 func DecryptWithDPAPI(_ []byte) ([]byte, error) {
-	return nil, nil
+	return nil, ErrDarwinNotSupportDPAPI
 }


### PR DESCRIPTION
## Proposed changes
1. FIX cookie decryption: Handle cases for current  mac chrome, trimming the value to remove ramdom bytes post decryption.

2. Fix password decryption: Introduced a new error ErrDarwinNotSupportDPAPI to clearly indicate the lack of support for DPAPI on macOS. It also allows the password decryption by keychain.