### PR TITLE
fix cookie and password decryption for macOS

### DIFF
--- a/browserdata/cookie/cookie.go
+++ b/browserdata/cookie/cookie.go
@@ -87,10 +87,12 @@ func (c *ChromiumCookie) Extract(masterKey []byte) error {
 				value, err = crypto.DecryptWithChromium(masterKey, encryptValue)
 				if err != nil {
 					log.Debugf("decrypt chromium cookie error: %v", err)
+				} else if len(value) > 32 {
+					// https://gist.github.com/kosh04/36cf6023fb75b516451ce933b9db2207?permalink_comment_id=5291243#gistcomment-5291243
+					value = value[32:]
 				}
 			}
 		}
-
 		cookie.Value = string(value)
 		*c = append(*c, cookie)
 	}

--- a/crypto/crypto_darwin.go
+++ b/crypto/crypto_darwin.go
@@ -2,6 +2,10 @@
 
 package crypto
 
+import "errors"
+
+var ErrDarwinNotSupportDPAPI = errors.New("darwin not support dpapi")
+
 func DecryptWithChromium(key, password []byte) ([]byte, error) {
 	if len(password) <= 3 {
 		return nil, ErrCiphertextLengthIsInvalid
@@ -11,5 +15,5 @@ func DecryptWithChromium(key, password []byte) ([]byte, error) {
 }
 
 func DecryptWithDPAPI(_ []byte) ([]byte, error) {
-	return nil, nil
+	return nil, ErrDarwinNotSupportDPAPI
 }


### PR DESCRIPTION
1. FIX cookie decryption: Handle cases for current mac chrome, trimming the value to remove ramdom bytes post decryption.
2. Fix password decryption: Introduced a new error ErrDarwinNotSupportDPAPI to clearly indicate the lack of support for DPAPI on macOS. It also allows the password decryption by keychain.