### PR TITLE
fix: update Firefox bookmark title handling

### DIFF
--- a/browserdata/bookmark/bookmark.go
+++ b/browserdata/bookmark/bookmark.go
@@ -121,14 +121,15 @@ func (f *FirefoxBookmark) Extract(_ []byte) error {
 	for rows.Next() {
 		var (
 			id, bt, dateAdded int64
-			title, url        string
+			url               string
+			title             sql.NullString
 		)
 		if err = rows.Scan(&id, &url, &bt, &dateAdded, &title); err != nil {
 			log.Debugf("scan bookmark error: %v", err)
 		}
 		*f = append(*f, bookmark{
 			ID:        id,
-			Name:      title,
+			Name:      title.String,
 			Type:      linkType(bt),
 			URL:       url,
 			DateAdded: typeutil.TimeStamp(dateAdded / 1000000),


### PR DESCRIPTION
## Proposed changes

The program would return an error if the Firefox bookmark title was empty; I solved this problem.

<img width="1510" height="510" alt="image" src="https://github.com/user-attachments/assets/7cba7698-9872-4a10-9461-375b8c0ec334" />


## Checklist

<!-- Put an "x" in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Pull request is created against the [dev](https://github.com/moonD4rk/HackBrowserData/tree/dev) branch
- [ ] All checks passed (lint, unit, build tests etc.) with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)