### PR TITLE
fix: macOS decrypt DPAPI fallback and cookie decryption

### DIFF
--- a/browserdata/cookie/cookie.go
+++ b/browserdata/cookie/cookie.go
@@ -87,10 +87,12 @@ func (c *ChromiumCookie) Extract(masterKey []byte) error {
 				value, err = crypto.DecryptWithChromium(masterKey, encryptValue)
 				if err != nil {
 					log.Debugf("decrypt chromium cookie error: %v", err)
+				} else if len(value) > 32 {
+					// https://gist.github.com/kosh04/36cf6023fb75b516451ce933b9db2207?permalink_comment_id=5291243#gistcomment-5291243
+					value = value[32:]
 				}
 			}
 		}
-
 		cookie.Value = string(value)
 		*c = append(*c, cookie)
 	}

--- a/crypto/crypto_darwin.go
+++ b/crypto/crypto_darwin.go
@@ -2,6 +2,10 @@
 
 package crypto
 
+import "errors"
+
+var ErrDarwinNotSupportDPAPI = errors.New("darwin not support dpapi")
+
 func DecryptWithChromium(key, password []byte) ([]byte, error) {
 	if len(password) <= 3 {
 		return nil, ErrCiphertextLengthIsInvalid
@@ -11,5 +15,5 @@ func DecryptWithChromium(key, password []byte) ([]byte, error) {
 }
 
 func DecryptWithDPAPI(_ []byte) ([]byte, error) {
-	return nil, nil
+	return nil, ErrDarwinNotSupportDPAPI
 }


### PR DESCRIPTION
Cherry-pick #465 from `dev` to `main`.