### PR TITLE
docs(readme): reflect Safari, Windows ABE  support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,59 +6,61 @@
 
 [![Lint](https://github.com/moonD4rk/HackBrowserData/actions/workflows/lint.yml/badge.svg)](https://github.com/moonD4rk/HackBrowserData/actions/workflows/lint.yml) [![Build](https://github.com/moonD4rk/HackBrowserData/actions/workflows/build.yml/badge.svg)](https://github.com/moonD4rk/HackBrowserData/actions/workflows/build.yml) [![Release](https://github.com/moonD4rk/HackBrowserData/actions/workflows/release.yml/badge.svg)](https://github.com/moonD4rk/HackBrowserData/actions/workflows/release.yml) [![Tests](https://github.com/moonD4rk/HackBrowserData/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/moonD4rk/HackBrowserData/actions/workflows/test.yml) [![codecov](https://codecov.io/gh/moonD4rk/HackBrowserData/branch/main/graph/badge.svg?token=KWJCN38657)](https://codecov.io/gh/moonD4rk/HackBrowserData)
 
-`HackBrowserData` is a command-line tool for decrypting and exporting browser data (passwords, history, cookies, bookmarks, credit cards, download history, localStorage, sessionStorage and extensions) from the browser. It supports the most popular browsers on the market and runs on Windows, macOS and Linux.
+`HackBrowserData` is a command-line tool for decrypting and exporting browser data (passwords, history, cookies, bookmarks, credit cards, download history, localStorage, sessionStorage and extensions) from the browser. It supports the most popular Chromium-based browsers and Firefox on Windows, macOS and Linux, plus Safari on macOS.
 
 > Disclaimer: This tool is only intended for security research. Users are responsible for all legal and related liabilities resulting from the use of this tool. The original author does not assume any legal responsibility.
 
 ## Supported Data Categories
 
-| Category       | Chromium-based | Firefox |
-|:---------------|:--------------:|:-------:|
-| Password       |       ✅        |    ✅    |
-| Cookie         |       ✅        |    ✅    |
-| Bookmark       |       ✅        |    ✅    |
-| History        |       ✅        |    ✅    |
-| Download       |       ✅        |    ✅    |
-| Credit Card    |       ✅        |    -    |
-| Extension      |       ✅        |    ✅    |
-| LocalStorage   |       ✅        |    ✅    |
-| SessionStorage |       ✅        |    -    |
+| Category       | Chromium-based | Firefox | Safari |
+|:---------------|:--------------:|:-------:|:------:|
+| Password       |       ✅        |    ✅    |   ✅    |
+| Cookie         |       ✅        |    ✅    |   ✅    |
+| Bookmark       |       ✅        |    ✅    |   ✅    |
+| History        |       ✅        |    ✅    |   ✅    |
+| Download       |       ✅        |    ✅    |   ✅    |
+| Credit Card    |       ✅        |    -    |   -    |
+| Extension      |       ✅        |    ✅    |   ✅    |
+| LocalStorage   |       ✅        |    ✅    |   ✅    |
+| SessionStorage |       ✅        |    -    |   -    |
 
 ## Supported Browsers
 
 > On macOS, some Chromium-based browsers **require a current user password** to decrypt.
+>
+> Password decryption may fail on macOS 26.4 or later.
 
 | Browser        | Windows | macOS | Linux |
 |:---------------|:-------:|:-----:|:-----:|
-| Chrome         |    ✅    |   ✅   |   ✅   |
+| Chrome         |   ✅²   |   ✅   |   ✅   |
 | Chrome Beta    |    ✅    |   ✅   |   ✅   |
 | Chromium       |    ✅    |   ✅   |   ✅   |
-| Edge           |    ✅    |   ✅   |   ✅   |
-| Brave          |    ✅    |   ✅   |   ✅   |
+| Edge           |   ✅²   |   ✅   |   ✅   |
+| Brave          |   ✅²   |   ✅   |   ✅   |
 | Opera          |    ✅    |   ✅   |   ✅   |
 | OperaGX        |    ✅    |   ✅   |   -   |
 | Vivaldi        |    ✅    |   ✅   |   ✅   |
 | Yandex         |    ✅    |   ✅   |   -   |
-| CocCoc         |    ✅    |   ✅   |   -   |
+| CocCoc         |   ✅²   |   ✅   |   -   |
 | Arc            |    -    |   ✅   |   -   |
+| DuckDuckGo     |    ✅    |   -   |   -   |
 | QQ             |    ✅    |   -   |   -   |
 | 360 ChromeX    |    ✅    |   -   |   -   |
 | 360 Chrome     |    ✅    |   -   |   -   |
 | DC Browser     |    ✅    |   -   |   -   |
 | Sogou Explorer |    ✅    |   -   |   -   |
 | Firefox        |    ✅    |   ✅   |   ✅   |
+| Safari¹        |    -    |   ✅   |   -   |
+
+> ¹ Safari requires Full Disk Access; macOS will prompt on first run — grant it to allow extraction.
+>
+> ² On Windows, decrypting Chromium 127+ cookies (Chrome / Edge / Brave / CocCoc) requires the App-Bound Encryption payload built via `make build-windows` — see [Building from source](#building-from-source) below.
 
 ## Getting Started
 
 ### Install
 
 Installation of `HackBrowserData` is dead-simple, just download [the release for your system](https://github.com/moonD4rk/HackBrowserData/releases) and run the binary.
-
-You can also install via [Homebrew](https://brew.sh/):
-
-```bash
-brew install moonD4rk/tap/hack-browser-data
-```
 
 > In some situations, this security tool will be treated as a virus by Windows Defender or other antivirus software and can not be executed. The code is all open source, you can modify and compile by yourself.
 
@@ -72,15 +74,34 @@ cd HackBrowserData
 go build ./cmd/hack-browser-data/
 ```
 
-### Cross-platform build
+#### Cross-platform build
 
 ```bash
-# For Windows
+# For Windows (standard build, no Chromium 127+ ABE cookie support)
 GOOS=windows GOARCH=amd64 go build ./cmd/hack-browser-data/
 
 # For Linux
 GOOS=linux GOARCH=amd64 go build ./cmd/hack-browser-data/
 ```
+
+#### Windows build with App-Bound Encryption (optional)
+
+Chrome / Edge / Brave / CocCoc 127+ protect cookies with App-Bound Encryption. Decrypting those cookies requires a small C payload — [Zig](https://ziglang.org/) (0.13+) is the recommended C toolchain (the Makefile calls `zig cc`), though a Windows-targeting `gcc` such as MinGW-w64 also works.
+
+```bash
+# 1. Install Zig
+brew install zig                 # macOS
+scoop install zig                # Windows (scoop)
+# or download from https://ziglang.org/download/
+
+# 2. Build the payload (outputs crypto/windows/payload/abe_extractor_amd64.bin)
+make payload
+
+# 3. Cross-compile the Windows executable with the payload embedded
+make build-windows
+```
+
+The resulting `hack-browser-data.exe` includes full ABE cookie decryption on Chromium 127+.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ scoop install zig                # Windows (scoop)
 # 2. Build the payload (outputs crypto/windows/payload/abe_extractor_amd64.bin)
 make payload
 
-# 3. Cross-compile the Windows executable with the payload embedded
+# 3. Build hack-browser-data.exe with the ABE payload embedded
 make build-windows
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 | Browser        | Windows | macOS | Linux |
 |:---------------|:-------:|:-----:|:-----:|
 | Chrome         |   ✅²   |   ✅   |   ✅   |
-| Chrome Beta    |    ✅    |   ✅   |   ✅   |
+| Chrome Beta    |   ✅²   |   ✅   |   ✅   |
 | Chromium       |    ✅    |   ✅   |   ✅   |
 | Edge           |   ✅²   |   ✅   |   ✅   |
 | Brave          |   ✅²   |   ✅   |   ✅   |
@@ -52,9 +52,9 @@
 | Firefox        |    ✅    |   ✅   |   ✅   |
 | Safari¹        |    -    |   ✅   |   -   |
 
-> ¹ Safari requires Full Disk Access; macOS will prompt on first run — grant it to allow extraction.
+> ¹ Safari requires Full Disk Access; enable it in System Settings → Privacy & Security → Full Disk Access if extraction returns empty results.
 >
-> ² On Windows, decrypting Chromium 127+ cookies (Chrome / Edge / Brave / CocCoc) requires the App-Bound Encryption payload built via `make build-windows` — see [Building from source](#building-from-source) below.
+> ² On Windows, decrypting Chromium 127+ cookies (Chrome / Chrome Beta / Edge / Brave / CocCoc) requires the App-Bound Encryption payload built via `make build-windows` — see [Building from source](#building-from-source) below.
 
 ## Getting Started
 
@@ -86,7 +86,7 @@ GOOS=linux GOARCH=amd64 go build ./cmd/hack-browser-data/
 
 #### Windows build with App-Bound Encryption (optional)
 
-Chrome / Edge / Brave / CocCoc 127+ protect cookies with App-Bound Encryption. Decrypting those cookies requires a small C payload — [Zig](https://ziglang.org/) (0.13+) is the recommended C toolchain (the Makefile calls `zig cc`), though a Windows-targeting `gcc` such as MinGW-w64 also works.
+Chrome / Chrome Beta / Edge / Brave / CocCoc 127+ protect cookies with App-Bound Encryption. Decrypting those cookies requires a small C payload — [Zig](https://ziglang.org/) (0.13+) is the recommended C toolchain (the Makefile calls `zig cc`). MinGW-w64 `gcc` can also build the sources manually if you bypass `make payload`.
 
 ```bash
 # 1. Install Zig


### PR DESCRIPTION
## Summary
- Add Safari column to the Supported Data Categories table (passwords, cookies, bookmarks, history, downloads, localStorage, extensions)
- Add Safari and DuckDuckGo rows to the Supported Browsers matrix with footnotes for Full Disk Access and Windows Chromium 127+ App-Bound Encryption
- Rewrite Building from source: split standard cross-compile from the optional Windows ABE build, document `make payload` / `make build-windows` and the Zig (recommended) / MinGW gcc toolchain choice
- Add macOS 26.4+ password decryption caveat; drop the stale Homebrew install snippet (tap not published)

## Test plan
- [x] Render `README.md` on GitHub and confirm tables, footnotes, and the nested `####` build subsections display correctly
- [x] Verify the `make payload` and `make build-windows` commands work as documented on a fresh checkout with Zig installed