### PR TITLE
ci(release): integrate Windows ABE payload into goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,23 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Run mode'
+        type: choice
+        options:
+          - snapshot
+          - release
+        default: snapshot
+      tag:
+        description: 'Release tag (required for release mode, e.g., v0.5.0)'
+        required: false
+        type: string
+      draft:
+        description: 'Publish as draft (release mode only)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -10,6 +27,12 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate inputs
+        if: inputs.mode == 'release' && inputs.tag == ''
+        run: |
+          echo "::error::tag is required when mode=release"
+          exit 1
+
       - name: Check out code
         uses: actions/checkout@v6
         with:
@@ -20,11 +43,41 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Run GoReleaser
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+
+      - name: Create and push tag
+        if: inputs.mode == 'release'
+        run: |
+          git tag ${{ inputs.tag }}
+          git push origin ${{ inputs.tag }}
+
+      - name: Run GoReleaser (snapshot)
+        if: inputs.mode == 'snapshot'
         uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
-          args: release --clean --draft
+          args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Run GoReleaser (release)
+        if: inputs.mode == 'release'
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: '~> v2'
+          args: release --clean ${{ inputs.draft && '--draft' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Upload snapshot artifacts
+        if: inputs.mode == 'snapshot'
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapshot-dist
+          path: dist/
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,11 +48,24 @@ jobs:
         with:
           version: 0.16.0
 
+      - name: Build ABE payload
+        run: make payload
+
       - name: Create and push tag
         if: inputs.mode == 'release'
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
-          git tag ${{ inputs.tag }}
-          git push origin ${{ inputs.tag }}
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag '$TAG' already exists locally"
+            exit 1
+          fi
+          if git ls-remote --tags --exit-code origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag '$TAG' already exists on origin"
+            exit 1
+          fi
+          git tag -- "$TAG"
+          git push origin -- "$TAG"
 
       - name: Run GoReleaser (snapshot)
         if: inputs.mode == 'snapshot'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,6 @@ version: 2
 before:
   hooks:
     - go mod tidy
-    - make payload
 
 builds:
   - id: "hack-browser-data-windows-amd64"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,26 @@ version: 2
 before:
   hooks:
     - go mod tidy
+    - make payload
 
 builds:
+  - id: "hack-browser-data-windows-amd64"
+    main: ./cmd/hack-browser-data/
+    binary: hack-browser-data
+    env:
+      - CGO_ENABLED=0
+    goos: [windows]
+    goarch: [amd64]
+    tags:
+      - abe_embed
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.buildDate={{.Date}}
+
   - id: "hack-browser-data"
     main: ./cmd/hack-browser-data/
     binary: hack-browser-data
@@ -15,6 +33,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: "386"
+      - goos: windows
+        goarch: amd64
       - goos: windows
         goarch: "386"
       - goos: windows
@@ -29,6 +49,9 @@ builds:
 
 archives:
   - id: "archive"
+    ids:
+      - hack-browser-data-windows-amd64
+      - hack-browser-data
     formats:
       - tar.gz
     format_overrides:


### PR DESCRIPTION
## Summary
- Wires the Windows reflective-injection ABE payload into the GoReleaser pipeline so release archives for `windows-amd64` ship with it (previously only `make build-windows` produced an ABE-capable binary)
- Adds `mode` / `tag` / `draft` workflow inputs so releases can be triggered as snapshot dry-runs or real tagged drafts from the GitHub UI
- Snapshot mode uploads `dist/` as an artifact for offline verification

## Changes
- `.goreleaser.yml`: `make payload` in `before.hooks`; new `hack-browser-data-windows-amd64` build with `tags: [abe_embed]`; original build now ignores `windows/amd64`; `archives.ids` lists both builds
- `.github/workflows/release.yml`: `mode` (snapshot/release), `tag`, `draft` inputs; `mlugg/setup-zig@v2` installs zig 0.16.0; conditional snapshot vs release goreleaser steps; snapshot artifact upload
