### PR TITLE
fix(windows): silent default dump on double-click

### DIFF
--- a/cmd/hack-browser-data/main.go
+++ b/cmd/hack-browser-data/main.go
@@ -49,6 +49,7 @@ GitHub: https://github.com/moonD4rk/HackBrowserData`,
 }
 
 func main() {
+	configureDoubleClickMode()
 	if err := rootCmd().Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/hack-browser-data/main_others.go
+++ b/cmd/hack-browser-data/main_others.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package main
+
+func configureDoubleClickMode() {}

--- a/cmd/hack-browser-data/main_windows.go
+++ b/cmd/hack-browser-data/main_windows.go
@@ -5,16 +5,8 @@ package main
 import (
 	"github.com/inconshreveable/mousetrap"
 	"github.com/spf13/cobra"
-	"golang.org/x/sys/windows"
-)
 
-const swHide = 0
-
-var (
-	kernel32             = windows.NewLazySystemDLL("kernel32.dll")
-	user32               = windows.NewLazySystemDLL("user32.dll")
-	procGetConsoleWindow = kernel32.NewProc("GetConsoleWindow")
-	procShowWindow       = user32.NewProc("ShowWindow")
+	"github.com/moond4rk/hackbrowserdata/utils/winapi"
 )
 
 // configureDoubleClickMode hides the console and bypasses cobra's
@@ -25,9 +17,5 @@ func configureDoubleClickMode() {
 	}
 
 	cobra.MousetrapHelpText = ""
-
-	hwnd, _, _ := procGetConsoleWindow.Call()
-	if hwnd != 0 {
-		_, _, _ = procShowWindow.Call(hwnd, swHide)
-	}
+	winapi.HideConsoleWindow()
 }

--- a/cmd/hack-browser-data/main_windows.go
+++ b/cmd/hack-browser-data/main_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package main
+
+import (
+	"github.com/inconshreveable/mousetrap"
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/windows"
+)
+
+const swHide = 0
+
+var (
+	kernel32             = windows.NewLazySystemDLL("kernel32.dll")
+	user32               = windows.NewLazySystemDLL("user32.dll")
+	procGetConsoleWindow = kernel32.NewProc("GetConsoleWindow")
+	procShowWindow       = user32.NewProc("ShowWindow")
+)
+
+// configureDoubleClickMode hides the console and bypasses cobra's
+// double-click guard when launched from Explorer (issue #344).
+func configureDoubleClickMode() {
+	if !mousetrap.StartedByExplorer() {
+		return
+	}
+
+	cobra.MousetrapHelpText = ""
+
+	hwnd, _, _ := procGetConsoleWindow.Call()
+	if hwnd != 0 {
+		_, _, _ = procShowWindow.Call(hwnd, swHide)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/godbus/dbus/v5 v5.2.2
+	github.com/inconshreveable/mousetrap v1.1.0
 	github.com/moond4rk/binarycookies v1.0.2
 	github.com/moond4rk/keychainbreaker v0.2.5
 	github.com/moond4rk/plist v1.2.0
@@ -25,7 +26,6 @@ require (
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/otiai10/mint v1.6.3 // indirect

--- a/utils/winapi/console_windows.go
+++ b/utils/winapi/console_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package winapi
+
+var (
+	procGetConsoleWindow = Kernel32.NewProc("GetConsoleWindow")
+	procShowWindow       = User32.NewProc("ShowWindow")
+)
+
+const swHide = 0
+
+// HideConsoleWindow hides the console window attached to the current
+// process. Used when the binary is launched via Explorer double-click
+// so no cmd window appears.
+func HideConsoleWindow() {
+	hwnd, _, _ := procGetConsoleWindow.Call()
+	if hwnd == 0 {
+		return
+	}
+	_, _, _ = procShowWindow.Call(hwnd, swHide)
+}

--- a/utils/winapi/console_windows.go
+++ b/utils/winapi/console_windows.go
@@ -10,12 +10,12 @@ var (
 const swHide = 0
 
 // HideConsoleWindow hides the console window attached to the current
-// process. Used when the binary is launched via Explorer double-click
-// so no cmd window appears.
-func HideConsoleWindow() {
+// process. Returns true if the window was previously visible.
+func HideConsoleWindow() bool {
 	hwnd, _, _ := procGetConsoleWindow.Call()
 	if hwnd == 0 {
-		return
+		return false
 	}
-	_, _, _ = procShowWindow.Call(hwnd, swHide)
+	prev, _, _ := procShowWindow.Call(hwnd, swHide)
+	return prev != 0
 }

--- a/utils/winapi/winapi_windows.go
+++ b/utils/winapi/winapi_windows.go
@@ -24,6 +24,7 @@ var (
 	Kernel32 = windows.NewLazySystemDLL("kernel32.dll")
 	Ntdll    = windows.NewLazySystemDLL("ntdll.dll")
 	Crypt32  = windows.NewLazySystemDLL("crypt32.dll")
+	User32   = windows.NewLazySystemDLL("user32.dll")
 )
 
 // CallBoolErr wraps the common "r1 == 0 means failure" Win32 convention.


### PR DESCRIPTION
## Summary
- Detect Explorer-launched binaries (double-click) via cobra's `mousetrap` dependency and hide the auto-created console window
- The .exe runs the default `dump -b all -c all` silently, writing `results/` next to the .exe
- Command-line invocations (cmd.exe / PowerShell) are unchanged: full cobra CLI, all flags, verbose logging continue to work as before

## Implementation
- `cmd/hack-browser-data/main_windows.go` — Windows-only; calls `mousetrap.StartedByExplorer()` and `user32!ShowWindow` to hide console
- `cmd/hack-browser-data/main_others.go` — No-op stub for non-Windows platforms
- `cmd/hack-browser-data/main.go` — Calls `configureDoubleClickMode()` as the first line of `main()`
- `mousetrap` upgraded from indirect → direct dependency

## Test plan
- [x] macOS / Linux build unchanged (stub is no-op)
- [x] Windows cross-compile produces 11M binary (size unchanged from previous releases)
- [x] CLI mode on Windows sandbox: `hbd.exe -c password` shows full logs, exports 6 passwords with ABE retrieval intact (parent=ssh, `mousetrap.StartedByExplorer()` → false, `configureDoubleClickMode` no-op)
- [x] Double-click via `Shell.Application.ShellExecute` (parent=explorer.exe) — manually verified by maintainer: no cmd window, results written silently next to the .exe

Closes #344.