### PR TITLE
refactor(browser): publicize key-injection capability interfaces

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -111,11 +111,14 @@ func pickFromConfigs(configs []types.BrowserConfig, opts PickOptions) ([]Browser
 	return browsers, nil
 }
 
-// keyRetrieversSetter is an optional capability interface. Chromium variants implement it to
-// receive the per-tier master-key retrievers (V10 / V11 / V20) as a single Retrievers struct;
-// Firefox and Safari do not.
-type keyRetrieversSetter interface {
+// KeyManager is implemented by engines that accept externally-provided master-key retrievers (Chromium family only).
+type KeyManager interface {
 	SetKeyRetrievers(keyretriever.Retrievers)
+}
+
+// KeychainPasswordReceiver is implemented by engines that need the macOS login password (Safari only).
+type KeychainPasswordReceiver interface {
+	SetKeychainPassword(string)
 }
 
 // resolveGlobs expands glob patterns in browser configs' UserDataDir.

--- a/browser/browser_darwin.go
+++ b/browser/browser_darwin.go
@@ -155,20 +155,8 @@ func resolveKeychainPassword(flagPassword string) string {
 	return password
 }
 
-// keychainPasswordSetter is an optional capability interface satisfied by
-// Safari, which reads InternetPassword records directly from the login keychain.
-type keychainPasswordSetter interface {
-	SetKeychainPassword(string)
-}
-
-// newPlatformInjector returns a closure that injects the Chromium master-key
-// retriever and the Safari Keychain password into each Browser.
-//
-// Resolution is lazy: the keychain password prompt and retriever construction
-// are deferred until the first Browser that actually needs them passes through
-// the closure. Browsers that satisfy neither setter interface (e.g. Firefox)
-// short-circuit without ever touching the keychain, so `-b firefox` on macOS
-// no longer triggers a password prompt.
+// newPlatformInjector lazily wires retrievers (and the macOS keychain password) into each Browser;
+// `-b firefox` never triggers a keychain prompt because lazy resolution skips browsers that need neither.
 func newPlatformInjector(opts PickOptions) func(Browser) {
 	var (
 		password   string
@@ -176,8 +164,8 @@ func newPlatformInjector(opts PickOptions) func(Browser) {
 		resolved   bool
 	)
 	return func(b Browser) {
-		rs, needsRetrievers := b.(keyRetrieversSetter)
-		kps, needsKeychainPassword := b.(keychainPasswordSetter)
+		km, needsRetrievers := b.(KeyManager)
+		kps, needsKeychainPassword := b.(KeychainPasswordReceiver)
 		if !needsRetrievers && !needsKeychainPassword {
 			return
 		}
@@ -187,7 +175,7 @@ func newPlatformInjector(opts PickOptions) func(Browser) {
 			resolved = true
 		}
 		if needsRetrievers {
-			rs.SetKeyRetrievers(retrievers)
+			km.SetKeyRetrievers(retrievers)
 		}
 		if needsKeychainPassword {
 			kps.SetKeychainPassword(password)

--- a/browser/browser_linux.go
+++ b/browser/browser_linux.go
@@ -75,8 +75,8 @@ func platformBrowsers() []types.BrowserConfig {
 func newPlatformInjector(_ PickOptions) func(Browser) {
 	retrievers := keyretriever.DefaultRetrievers()
 	return func(b Browser) {
-		if s, ok := b.(keyRetrieversSetter); ok {
-			s.SetKeyRetrievers(retrievers)
+		if km, ok := b.(KeyManager); ok {
+			km.SetKeyRetrievers(retrievers)
 		}
 	}
 }

--- a/browser/browser_windows.go
+++ b/browser/browser_windows.go
@@ -132,8 +132,8 @@ func platformBrowsers() []types.BrowserConfig {
 func newPlatformInjector(_ PickOptions) func(Browser) {
 	retrievers := keyretriever.DefaultRetrievers()
 	return func(b Browser) {
-		if s, ok := b.(keyRetrieversSetter); ok {
-			s.SetKeyRetrievers(retrievers)
+		if km, ok := b.(KeyManager); ok {
+			km.SetKeyRetrievers(retrievers)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Promote private `keyRetrieversSetter` → public `KeyManager`; lift `keychainPasswordSetter` from `browser_darwin.go` into `browser.go` as `KeychainPasswordReceiver`.
- Type-assertion sites in `newPlatformInjector` (darwin / linux / windows) updated to the public interface names.
- Zero behavior change — chromium and safari engines already satisfy the new interfaces; firefox is unaffected.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./browser/... ./crypto/... ./types/...` all pass
- [x] Cross-compile darwin / linux / windows OK
- [x] `gofumpt -l browser/` + `goimports -l browser/` clean
- [x] Windows sandbox regression (windows-tunnel): 13 browsers / 719 cookies / 7 passwords / **0 non-ASCII bytes**