### PR TITLE
feat(keys): add cross-host master key export

### DIFF
--- a/browser/browser.go
+++ b/browser/browser.go
@@ -20,6 +20,7 @@ type Browser interface {
 	BrowserName() string
 	ProfileName() string
 	ProfileDir() string
+	UserDataDir() string
 	Extract(categories []types.Category) (*types.BrowserData, error)
 	CountEntries(categories []types.Category) (map[types.Category]int, error)
 }
@@ -114,6 +115,7 @@ func pickFromConfigs(configs []types.BrowserConfig, opts PickOptions) ([]Browser
 // KeyManager is implemented by engines that accept externally-provided master-key retrievers (Chromium family only).
 type KeyManager interface {
 	SetKeyRetrievers(keyretriever.Retrievers)
+	ExportKeys() (keyretriever.MasterKeys, error)
 }
 
 // KeychainPasswordReceiver is implemented by engines that need the macOS login password (Safari only).

--- a/browser/chromium/chromium.go
+++ b/browser/chromium/chromium.go
@@ -59,11 +59,50 @@ func (b *Browser) SetKeyRetrievers(r keyretriever.Retrievers) {
 
 func (b *Browser) BrowserName() string { return b.cfg.Name }
 func (b *Browser) ProfileDir() string  { return b.profileDir }
+func (b *Browser) UserDataDir() string { return b.cfg.UserDataDir }
 func (b *Browser) ProfileName() string {
 	if b.profileDir == "" {
 		return ""
 	}
 	return filepath.Base(b.profileDir)
+}
+
+// ExportKeys derives this profile's master keys without performing extraction.
+// It runs the same retrievers Extract would use and returns the assembled
+// MasterKeys plus a joined error (nil on full success, non-nil if any tier
+// failed). Used by cross-host workflows where keys are produced on one host
+// and consumed on another.
+func (b *Browser) ExportKeys() (keyretriever.MasterKeys, error) {
+	session, err := filemanager.NewSession()
+	if err != nil {
+		return keyretriever.MasterKeys{}, err
+	}
+	defer session.Cleanup()
+
+	var localStateDst string
+	for _, dir := range []string{filepath.Dir(b.profileDir), b.profileDir} {
+		candidate := filepath.Join(dir, "Local State")
+		if !fileutil.FileExists(candidate) {
+			continue
+		}
+		dst := filepath.Join(session.TempDir(), "Local State")
+		if err := session.Acquire(candidate, dst, false); err != nil {
+			break
+		}
+		localStateDst = dst
+		break
+	}
+
+	abeKey := ""
+	if b.cfg.WindowsABE {
+		abeKey = b.cfg.Key
+	}
+	hints := keyretriever.Hints{
+		KeychainLabel:  b.cfg.KeychainLabel,
+		WindowsABEKey:  abeKey,
+		LocalStatePath: localStateDst,
+	}
+	return keyretriever.NewMasterKeys(b.retrievers, hints)
 }
 
 // Extract copies browser files to a temp directory, retrieves the master key,

--- a/browser/chromium/chromium.go
+++ b/browser/chromium/chromium.go
@@ -68,10 +68,11 @@ func (b *Browser) ProfileName() string {
 }
 
 // ExportKeys derives this profile's master keys without performing extraction.
-// It runs the same retrievers Extract would use and returns the assembled
-// MasterKeys plus a joined error (nil on full success, non-nil if any tier
-// failed). Used by cross-host workflows where keys are produced on one host
-// and consumed on another.
+// Returns whatever tiers succeeded plus a joined error describing any failed
+// tiers; callers preserve partial results because a Chrome 127+ profile mixes
+// v10 + v20 ciphertexts and a v20-only failure must not erase a usable v10 key.
+// Used by cross-host workflows where keys are produced on one host and consumed
+// on another.
 func (b *Browser) ExportKeys() (keyretriever.MasterKeys, error) {
 	session, err := filemanager.NewSession()
 	if err != nil {
@@ -79,6 +80,15 @@ func (b *Browser) ExportKeys() (keyretriever.MasterKeys, error) {
 	}
 	defer session.Cleanup()
 
+	return keyretriever.NewMasterKeys(b.retrievers, b.buildHints(session))
+}
+
+// buildHints discovers Local State (acquiring it into session.TempDir so Windows DPAPI/ABE retrievers can
+// read it from a path the process owns) and assembles per-tier retriever hints. Shared by Extract and
+// ExportKeys so the two stay in lockstep. Multi-profile layout: Local State lives in the parent of
+// profileDir. Flat layout (Opera): Local State sits alongside data files inside profileDir.
+func (b *Browser) buildHints(session *filemanager.Session) keyretriever.Hints {
+	label := b.BrowserName() + "/" + b.ProfileName()
 	var localStateDst string
 	for _, dir := range []string{filepath.Dir(b.profileDir), b.profileDir} {
 		candidate := filepath.Join(dir, "Local State")
@@ -87,6 +97,7 @@ func (b *Browser) ExportKeys() (keyretriever.MasterKeys, error) {
 		}
 		dst := filepath.Join(session.TempDir(), "Local State")
 		if err := session.Acquire(candidate, dst, false); err != nil {
+			log.Debugf("acquire Local State for %s: %v", label, err)
 			break
 		}
 		localStateDst = dst
@@ -97,12 +108,11 @@ func (b *Browser) ExportKeys() (keyretriever.MasterKeys, error) {
 	if b.cfg.WindowsABE {
 		abeKey = b.cfg.Key
 	}
-	hints := keyretriever.Hints{
+	return keyretriever.Hints{
 		KeychainLabel:  b.cfg.KeychainLabel,
 		WindowsABEKey:  abeKey,
 		LocalStatePath: localStateDst,
 	}
-	return keyretriever.NewMasterKeys(b.retrievers, hints)
 }
 
 // Extract copies browser files to a temp directory, retrieves the master key,
@@ -214,42 +224,13 @@ var warnedMasterKeyFailure sync.Map
 
 // getMasterKeys retrieves master keys for all configured cipher tiers.
 func (b *Browser) getMasterKeys(session *filemanager.Session) keyretriever.MasterKeys {
-	label := b.BrowserName() + "/" + b.ProfileName()
-
-	// Locate and copy Local State (needed on Windows, ignored on macOS/Linux). Multi-profile
-	// layout: Local State is in the parent of profileDir. Flat layout (Opera): Local State is
-	// alongside data files in profileDir.
-	var localStateDst string
-	for _, dir := range []string{filepath.Dir(b.profileDir), b.profileDir} {
-		candidate := filepath.Join(dir, "Local State")
-		if !fileutil.FileExists(candidate) {
-			continue
-		}
-		dst := filepath.Join(session.TempDir(), "Local State")
-		if err := session.Acquire(candidate, dst, false); err != nil {
-			log.Debugf("acquire Local State for %s: %v", label, err)
-			break
-		}
-		localStateDst = dst
-		break
-	}
-
-	abeKey := ""
-	if b.cfg.WindowsABE {
-		abeKey = b.cfg.Key
-	}
-	hints := keyretriever.Hints{
-		KeychainLabel:  b.cfg.KeychainLabel,
-		WindowsABEKey:  abeKey,
-		LocalStatePath: localStateDst,
-	}
-	keys, err := keyretriever.NewMasterKeys(b.retrievers, hints)
+	keys, err := keyretriever.NewMasterKeys(b.retrievers, b.buildHints(session))
 	if err != nil {
 		installKey := b.BrowserName() + "|" + b.cfg.UserDataDir
 		if _, already := warnedMasterKeyFailure.LoadOrStore(installKey, struct{}{}); !already {
 			log.Warnf("%s: master key retrieval: %v", b.BrowserName(), err)
 		} else {
-			log.Debugf("%s: master key retrieval: %v", label, err)
+			log.Debugf("%s/%s: master key retrieval: %v", b.BrowserName(), b.ProfileName(), err)
 		}
 	}
 	return keys

--- a/browser/firefox/firefox.go
+++ b/browser/firefox/firefox.go
@@ -49,6 +49,7 @@ func NewBrowsers(cfg types.BrowserConfig) ([]*Browser, error) {
 
 func (b *Browser) BrowserName() string { return b.cfg.Name }
 func (b *Browser) ProfileDir() string  { return b.profileDir }
+func (b *Browser) UserDataDir() string { return b.cfg.UserDataDir }
 func (b *Browser) ProfileName() string {
 	if b.profileDir == "" {
 		return ""

--- a/browser/keydump.go
+++ b/browser/keydump.go
@@ -1,0 +1,60 @@
+package browser
+
+import (
+	"github.com/moond4rk/hackbrowserdata/crypto/keyretriever"
+	"github.com/moond4rk/hackbrowserdata/log"
+)
+
+// BuildDump assembles a cross-host Dump from a set of fully-wired browsers.
+// Browsers that do not implement KeyManager (Firefox, Safari) are skipped —
+// their master keys aren't portable across hosts. Profiles sharing the same
+// (BrowserName, UserDataDir) are grouped into one Installation and ExportKeys
+// runs only once per group, matching the per-installation nature of Chromium's
+// master keys.
+//
+// Per-installation ExportKeys failures are logged and the installation is
+// dropped; the rest of the dump proceeds. An empty browser list returns a
+// Dump with metadata but no Installations.
+func BuildDump(browsers []Browser) keyretriever.Dump {
+	dump := keyretriever.NewDump()
+
+	type instKey struct {
+		browser     string
+		userDataDir string
+	}
+	seen := make(map[instKey]int)
+
+	for _, b := range browsers {
+		km, ok := b.(KeyManager)
+		if !ok {
+			log.Debugf("dump-keys: %s skipped (not key-portable)", b.BrowserName())
+			continue
+		}
+
+		key := instKey{b.BrowserName(), b.UserDataDir()}
+		if idx, exists := seen[key]; exists {
+			dump.Installations[idx].Profiles = append(dump.Installations[idx].Profiles, b.ProfileName())
+			continue
+		}
+
+		keys, err := km.ExportKeys()
+		if err != nil {
+			log.Warnf("dump-keys: %s/%s export failed: %v", b.BrowserName(), b.ProfileName(), err)
+			continue
+		}
+
+		seen[key] = len(dump.Installations)
+		dump.Installations = append(dump.Installations, keyretriever.Installation{
+			Browser:     b.BrowserName(),
+			UserDataDir: b.UserDataDir(),
+			Profiles:    []string{b.ProfileName()},
+			Keys: keyretriever.InstallKeys{
+				V10: keys.V10,
+				V11: keys.V11,
+				V20: keys.V20,
+			},
+		})
+	}
+
+	return dump
+}

--- a/browser/keydump.go
+++ b/browser/keydump.go
@@ -6,37 +6,66 @@ import (
 )
 
 // BuildDump exports per-installation master keys; profiles sharing (Browser, UserDataDir) collapse into one Vault.
-// Browsers without KeyManager (Firefox/Safari) are skipped; per-vault ExportKeys failures drop just that vault.
+// Browsers without KeyManager (Firefox/Safari) are skipped. ExportKeys is invoked exactly once per installation
+// regardless of profile count or success. Partial results (e.g. V10 retrieved, V20 failed) keep the usable tiers
+// rather than discarding the vault, matching getMasterKeys' behavior on the extraction path — a Chrome 127+
+// profile mixes v10 + v20 ciphertexts and a v20-only failure must not erase a usable v10 key.
 func BuildDump(browsers []Browser) keyretriever.Dump {
 	dump := keyretriever.NewDump()
-	for _, b := range browsers {
-		if km, ok := b.(KeyManager); ok {
-			addBrowserToDump(&dump, b, km)
+	groups, order := groupByInstallation(browsers)
+	for _, key := range order {
+		g := groups[key]
+		keys, err := g.km.ExportKeys()
+		if err != nil {
+			status := "partial"
+			if !keys.HasAny() {
+				status = "failed"
+			}
+			log.Warnf("dump-keys: %s/%s %s: %v", g.browser, g.profiles[0], status, err)
 		}
+		if !keys.HasAny() {
+			continue
+		}
+		dump.Vaults = append(dump.Vaults, keyretriever.Vault{
+			Browser:     g.browser,
+			UserDataDir: g.userDataDir,
+			Profiles:    g.profiles,
+			Keys:        keys,
+		})
 	}
 	return dump
 }
 
-func addBrowserToDump(dump *keyretriever.Dump, b Browser, km KeyManager) {
-	name := b.BrowserName()
-	udd := b.UserDataDir()
-	for i := range dump.Vaults {
-		existing := &dump.Vaults[i]
-		if existing.Browser == name && existing.UserDataDir == udd {
-			existing.Profiles = append(existing.Profiles, b.ProfileName())
-			return
+type installGroup struct {
+	browser, userDataDir string
+	km                   KeyManager
+	profiles             []string
+}
+
+// groupByInstallation collects browsers into per-installation groups keyed by (BrowserName, UserDataDir),
+// preserving the discovery order of the first profile in each group. Non-KeyManager browsers are skipped.
+// Doing the grouping up front (rather than checking dump.Vaults profile-by-profile) makes the resulting
+// Profiles list complete and order-independent even if the group's ExportKeys later fails.
+func groupByInstallation(browsers []Browser) (map[string]*installGroup, []string) {
+	groups := make(map[string]*installGroup)
+	var order []string
+	for _, b := range browsers {
+		km, ok := b.(KeyManager)
+		if !ok {
+			continue
 		}
+		key := b.BrowserName() + "|" + b.UserDataDir()
+		if g, exists := groups[key]; exists {
+			g.profiles = append(g.profiles, b.ProfileName())
+			continue
+		}
+		groups[key] = &installGroup{
+			browser:     b.BrowserName(),
+			userDataDir: b.UserDataDir(),
+			km:          km,
+			profiles:    []string{b.ProfileName()},
+		}
+		order = append(order, key)
 	}
-	keys, err := km.ExportKeys()
-	if err != nil {
-		log.Warnf("dump-keys: %s/%s export failed: %v", name, b.ProfileName(), err)
-		return
-	}
-	vault := keyretriever.Vault{
-		Browser:     name,
-		UserDataDir: udd,
-		Profiles:    []string{b.ProfileName()},
-		Keys:        keys,
-	}
-	dump.Vaults = append(dump.Vaults, vault)
+	return groups, order
 }

--- a/browser/keydump.go
+++ b/browser/keydump.go
@@ -5,56 +5,38 @@ import (
 	"github.com/moond4rk/hackbrowserdata/log"
 )
 
-// BuildDump assembles a cross-host Dump from a set of fully-wired browsers.
-// Browsers that do not implement KeyManager (Firefox, Safari) are skipped —
-// their master keys aren't portable across hosts. Profiles sharing the same
-// (BrowserName, UserDataDir) are grouped into one Installation and ExportKeys
-// runs only once per group, matching the per-installation nature of Chromium's
-// master keys.
-//
-// Per-installation ExportKeys failures are logged and the installation is
-// dropped; the rest of the dump proceeds. An empty browser list returns a
-// Dump with metadata but no Installations.
+// BuildDump exports per-installation master keys; profiles sharing (Browser, UserDataDir) collapse into one Vault.
+// Browsers without KeyManager (Firefox/Safari) are skipped; per-vault ExportKeys failures drop just that vault.
 func BuildDump(browsers []Browser) keyretriever.Dump {
 	dump := keyretriever.NewDump()
-
-	type instKey struct {
-		browser     string
-		userDataDir string
-	}
-	seen := make(map[instKey]int)
-
 	for _, b := range browsers {
-		km, ok := b.(KeyManager)
-		if !ok {
-			log.Debugf("dump-keys: %s skipped (not key-portable)", b.BrowserName())
-			continue
+		if km, ok := b.(KeyManager); ok {
+			addBrowserToDump(&dump, b, km)
 		}
-
-		key := instKey{b.BrowserName(), b.UserDataDir()}
-		if idx, exists := seen[key]; exists {
-			dump.Installations[idx].Profiles = append(dump.Installations[idx].Profiles, b.ProfileName())
-			continue
-		}
-
-		keys, err := km.ExportKeys()
-		if err != nil {
-			log.Warnf("dump-keys: %s/%s export failed: %v", b.BrowserName(), b.ProfileName(), err)
-			continue
-		}
-
-		seen[key] = len(dump.Installations)
-		dump.Installations = append(dump.Installations, keyretriever.Installation{
-			Browser:     b.BrowserName(),
-			UserDataDir: b.UserDataDir(),
-			Profiles:    []string{b.ProfileName()},
-			Keys: keyretriever.InstallKeys{
-				V10: keys.V10,
-				V11: keys.V11,
-				V20: keys.V20,
-			},
-		})
 	}
-
 	return dump
+}
+
+func addBrowserToDump(dump *keyretriever.Dump, b Browser, km KeyManager) {
+	name := b.BrowserName()
+	udd := b.UserDataDir()
+	for i := range dump.Vaults {
+		existing := &dump.Vaults[i]
+		if existing.Browser == name && existing.UserDataDir == udd {
+			existing.Profiles = append(existing.Profiles, b.ProfileName())
+			return
+		}
+	}
+	keys, err := km.ExportKeys()
+	if err != nil {
+		log.Warnf("dump-keys: %s/%s export failed: %v", name, b.ProfileName(), err)
+		return
+	}
+	vault := keyretriever.Vault{
+		Browser:     name,
+		UserDataDir: udd,
+		Profiles:    []string{b.ProfileName()},
+		Keys:        keys,
+	}
+	dump.Vaults = append(dump.Vaults, vault)
 }

--- a/browser/keydump_test.go
+++ b/browser/keydump_test.go
@@ -1,0 +1,168 @@
+package browser
+
+import (
+	"bytes"
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/moond4rk/hackbrowserdata/crypto/keyretriever"
+	"github.com/moond4rk/hackbrowserdata/types"
+)
+
+type mockBrowser struct {
+	name, profile, profileDir, userDataDir string
+}
+
+func (m *mockBrowser) BrowserName() string { return m.name }
+func (m *mockBrowser) ProfileName() string { return m.profile }
+func (m *mockBrowser) ProfileDir() string  { return m.profileDir }
+func (m *mockBrowser) UserDataDir() string { return m.userDataDir }
+
+func (m *mockBrowser) Extract(_ []types.Category) (*types.BrowserData, error) {
+	return &types.BrowserData{}, nil
+}
+
+func (m *mockBrowser) CountEntries(_ []types.Category) (map[types.Category]int, error) {
+	return nil, nil
+}
+
+type mockChromiumBrowser struct {
+	mockBrowser
+	keys      keyretriever.MasterKeys
+	exportErr error
+}
+
+func (m *mockChromiumBrowser) SetKeyRetrievers(_ keyretriever.Retrievers) {}
+
+func (m *mockChromiumBrowser) ExportKeys() (keyretriever.MasterKeys, error) {
+	return m.keys, m.exportErr
+}
+
+func TestBuildDump_Empty(t *testing.T) {
+	dump := BuildDump(nil)
+	if dump.Version != keyretriever.DumpVersion {
+		t.Errorf("Version = %q, want %q", dump.Version, keyretriever.DumpVersion)
+	}
+	if dump.Host.OS != runtime.GOOS {
+		t.Errorf("Host.OS = %q, want %q", dump.Host.OS, runtime.GOOS)
+	}
+	if len(dump.Installations) != 0 {
+		t.Errorf("Installations len = %d, want 0", len(dump.Installations))
+	}
+}
+
+func TestBuildDump_SingleChromium(t *testing.T) {
+	b := &mockChromiumBrowser{
+		mockBrowser: mockBrowser{name: "Chrome", profile: "Default", profileDir: "/p/Default", userDataDir: "/p"},
+		keys:        keyretriever.MasterKeys{V10: []byte("v10-key")},
+	}
+
+	dump := BuildDump([]Browser{b})
+
+	if len(dump.Installations) != 1 {
+		t.Fatalf("Installations len = %d, want 1", len(dump.Installations))
+	}
+	inst := dump.Installations[0]
+	if inst.Browser != "Chrome" || inst.UserDataDir != "/p" {
+		t.Errorf("inst metadata = %+v", inst)
+	}
+	if len(inst.Profiles) != 1 || inst.Profiles[0] != "Default" {
+		t.Errorf("Profiles = %v", inst.Profiles)
+	}
+	if string(inst.Keys.V10) != "v10-key" {
+		t.Errorf("Keys.V10 = %q", inst.Keys.V10)
+	}
+}
+
+func TestBuildDump_MultipleProfilesSameInstallation(t *testing.T) {
+	p1 := &mockChromiumBrowser{
+		mockBrowser: mockBrowser{name: "Chrome", profile: "Default", userDataDir: "/p"},
+		keys:        keyretriever.MasterKeys{V10: []byte("v10")},
+	}
+	p2 := &mockChromiumBrowser{
+		mockBrowser: mockBrowser{name: "Chrome", profile: "Profile 1", userDataDir: "/p"},
+		exportErr:   errors.New("ExportKeys should not be called for second profile"),
+	}
+
+	dump := BuildDump([]Browser{p1, p2})
+
+	if len(dump.Installations) != 1 {
+		t.Fatalf("Installations len = %d, want 1 (same installation grouping)", len(dump.Installations))
+	}
+	if len(dump.Installations[0].Profiles) != 2 {
+		t.Errorf("Profiles = %v, want both Default and Profile 1", dump.Installations[0].Profiles)
+	}
+}
+
+func TestBuildDump_SkipsNonKeyManager(t *testing.T) {
+	chrome := &mockChromiumBrowser{
+		mockBrowser: mockBrowser{name: "Chrome", profile: "Default", userDataDir: "/chrome"},
+		keys:        keyretriever.MasterKeys{V10: []byte("v10")},
+	}
+	firefox := &mockBrowser{name: "Firefox", profile: "default-release", userDataDir: "/ff"}
+
+	dump := BuildDump([]Browser{chrome, firefox})
+
+	if len(dump.Installations) != 1 {
+		t.Fatalf("Installations len = %d, want 1 (Firefox skipped)", len(dump.Installations))
+	}
+	if dump.Installations[0].Browser != "Chrome" {
+		t.Errorf("Browser = %q, want Chrome", dump.Installations[0].Browser)
+	}
+}
+
+func TestBuildDump_SkipsExportError(t *testing.T) {
+	good := &mockChromiumBrowser{
+		mockBrowser: mockBrowser{name: "Chrome", profile: "Default", userDataDir: "/chrome"},
+		keys:        keyretriever.MasterKeys{V10: []byte("v10")},
+	}
+	failing := &mockChromiumBrowser{
+		mockBrowser: mockBrowser{name: "Edge", profile: "Default", userDataDir: "/edge"},
+		exportErr:   errors.New("retriever failed"),
+	}
+
+	dump := BuildDump([]Browser{good, failing})
+
+	if len(dump.Installations) != 1 {
+		t.Fatalf("Installations len = %d, want 1 (Edge skipped on export error)", len(dump.Installations))
+	}
+	if dump.Installations[0].Browser != "Chrome" {
+		t.Errorf("Browser = %q, want Chrome", dump.Installations[0].Browser)
+	}
+}
+
+func TestBuildDump_JSONRoundTrip(t *testing.T) {
+	b := &mockChromiumBrowser{
+		mockBrowser: mockBrowser{name: "Chrome", profile: "Default", userDataDir: "/p"},
+		keys:        keyretriever.MasterKeys{V10: []byte{0x01, 0x02, 0x03}, V20: []byte{0xff, 0xee}},
+	}
+
+	dump := BuildDump([]Browser{b})
+
+	var buf bytes.Buffer
+	if err := dump.WriteJSON(&buf); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	parsed, err := keyretriever.ReadJSON(&buf)
+	if err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+
+	if parsed.Version != dump.Version {
+		t.Errorf("Version round-trip: got %q, want %q", parsed.Version, dump.Version)
+	}
+	if len(parsed.Installations) != 1 {
+		t.Fatalf("Installations len = %d", len(parsed.Installations))
+	}
+	if !bytes.Equal(parsed.Installations[0].Keys.V10, dump.Installations[0].Keys.V10) {
+		t.Errorf("V10 round-trip mismatch")
+	}
+	if !bytes.Equal(parsed.Installations[0].Keys.V20, dump.Installations[0].Keys.V20) {
+		t.Errorf("V20 round-trip mismatch")
+	}
+	if parsed.Installations[0].Keys.V11 != nil {
+		t.Errorf("V11 should be omitted (nil), got %v", parsed.Installations[0].Keys.V11)
+	}
+}

--- a/browser/keydump_test.go
+++ b/browser/keydump_test.go
@@ -10,6 +10,13 @@ import (
 	"github.com/moond4rk/hackbrowserdata/types"
 )
 
+const (
+	testProfileDefault = "Default"
+	testProfile1       = "Profile 1"
+	testUDD            = "/p"
+	testEdgeName       = "Edge"
+)
+
 type mockBrowser struct {
 	name, profile, profileDir, userDataDir string
 }
@@ -47,27 +54,27 @@ func TestBuildDump_Empty(t *testing.T) {
 	if dump.Host.OS != runtime.GOOS {
 		t.Errorf("Host.OS = %q, want %q", dump.Host.OS, runtime.GOOS)
 	}
-	if len(dump.Installations) != 0 {
-		t.Errorf("Installations len = %d, want 0", len(dump.Installations))
+	if len(dump.Vaults) != 0 {
+		t.Errorf("Vaults len = %d, want 0", len(dump.Vaults))
 	}
 }
 
 func TestBuildDump_SingleChromium(t *testing.T) {
 	b := &mockChromiumBrowser{
-		mockBrowser: mockBrowser{name: "Chrome", profile: "Default", profileDir: "/p/Default", userDataDir: "/p"},
+		mockBrowser: mockBrowser{name: chromeName, profile: testProfileDefault, profileDir: "/p/Default", userDataDir: testUDD},
 		keys:        keyretriever.MasterKeys{V10: []byte("v10-key")},
 	}
 
 	dump := BuildDump([]Browser{b})
 
-	if len(dump.Installations) != 1 {
-		t.Fatalf("Installations len = %d, want 1", len(dump.Installations))
+	if len(dump.Vaults) != 1 {
+		t.Fatalf("Vaults len = %d, want 1", len(dump.Vaults))
 	}
-	inst := dump.Installations[0]
-	if inst.Browser != "Chrome" || inst.UserDataDir != "/p" {
+	inst := dump.Vaults[0]
+	if inst.Browser != chromeName || inst.UserDataDir != testUDD {
 		t.Errorf("inst metadata = %+v", inst)
 	}
-	if len(inst.Profiles) != 1 || inst.Profiles[0] != "Default" {
+	if len(inst.Profiles) != 1 || inst.Profiles[0] != testProfileDefault {
 		t.Errorf("Profiles = %v", inst.Profiles)
 	}
 	if string(inst.Keys.V10) != "v10-key" {
@@ -77,64 +84,64 @@ func TestBuildDump_SingleChromium(t *testing.T) {
 
 func TestBuildDump_MultipleProfilesSameInstallation(t *testing.T) {
 	p1 := &mockChromiumBrowser{
-		mockBrowser: mockBrowser{name: "Chrome", profile: "Default", userDataDir: "/p"},
+		mockBrowser: mockBrowser{name: chromeName, profile: testProfileDefault, userDataDir: testUDD},
 		keys:        keyretriever.MasterKeys{V10: []byte("v10")},
 	}
 	p2 := &mockChromiumBrowser{
-		mockBrowser: mockBrowser{name: "Chrome", profile: "Profile 1", userDataDir: "/p"},
+		mockBrowser: mockBrowser{name: chromeName, profile: testProfile1, userDataDir: testUDD},
 		exportErr:   errors.New("ExportKeys should not be called for second profile"),
 	}
 
 	dump := BuildDump([]Browser{p1, p2})
 
-	if len(dump.Installations) != 1 {
-		t.Fatalf("Installations len = %d, want 1 (same installation grouping)", len(dump.Installations))
+	if len(dump.Vaults) != 1 {
+		t.Fatalf("Vaults len = %d, want 1 (same installation grouping)", len(dump.Vaults))
 	}
-	if len(dump.Installations[0].Profiles) != 2 {
-		t.Errorf("Profiles = %v, want both Default and Profile 1", dump.Installations[0].Profiles)
+	if len(dump.Vaults[0].Profiles) != 2 {
+		t.Errorf("Profiles = %v, want both profiles", dump.Vaults[0].Profiles)
 	}
 }
 
 func TestBuildDump_SkipsNonKeyManager(t *testing.T) {
 	chrome := &mockChromiumBrowser{
-		mockBrowser: mockBrowser{name: "Chrome", profile: "Default", userDataDir: "/chrome"},
+		mockBrowser: mockBrowser{name: chromeName, profile: testProfileDefault, userDataDir: "/chrome"},
 		keys:        keyretriever.MasterKeys{V10: []byte("v10")},
 	}
-	firefox := &mockBrowser{name: "Firefox", profile: "default-release", userDataDir: "/ff"}
+	firefox := &mockBrowser{name: firefoxName, profile: "default-release", userDataDir: "/ff"}
 
 	dump := BuildDump([]Browser{chrome, firefox})
 
-	if len(dump.Installations) != 1 {
-		t.Fatalf("Installations len = %d, want 1 (Firefox skipped)", len(dump.Installations))
+	if len(dump.Vaults) != 1 {
+		t.Fatalf("Vaults len = %d, want 1 (firefox skipped)", len(dump.Vaults))
 	}
-	if dump.Installations[0].Browser != "Chrome" {
-		t.Errorf("Browser = %q, want Chrome", dump.Installations[0].Browser)
+	if dump.Vaults[0].Browser != chromeName {
+		t.Errorf("Browser = %q, want %q", dump.Vaults[0].Browser, chromeName)
 	}
 }
 
 func TestBuildDump_SkipsExportError(t *testing.T) {
 	good := &mockChromiumBrowser{
-		mockBrowser: mockBrowser{name: "Chrome", profile: "Default", userDataDir: "/chrome"},
+		mockBrowser: mockBrowser{name: chromeName, profile: testProfileDefault, userDataDir: "/chrome"},
 		keys:        keyretriever.MasterKeys{V10: []byte("v10")},
 	}
 	failing := &mockChromiumBrowser{
-		mockBrowser: mockBrowser{name: "Edge", profile: "Default", userDataDir: "/edge"},
+		mockBrowser: mockBrowser{name: testEdgeName, profile: testProfileDefault, userDataDir: "/edge"},
 		exportErr:   errors.New("retriever failed"),
 	}
 
 	dump := BuildDump([]Browser{good, failing})
 
-	if len(dump.Installations) != 1 {
-		t.Fatalf("Installations len = %d, want 1 (Edge skipped on export error)", len(dump.Installations))
+	if len(dump.Vaults) != 1 {
+		t.Fatalf("Vaults len = %d, want 1 (failing browser skipped)", len(dump.Vaults))
 	}
-	if dump.Installations[0].Browser != "Chrome" {
-		t.Errorf("Browser = %q, want Chrome", dump.Installations[0].Browser)
+	if dump.Vaults[0].Browser != chromeName {
+		t.Errorf("Browser = %q, want %q", dump.Vaults[0].Browser, chromeName)
 	}
 }
 
 func TestBuildDump_JSONRoundTrip(t *testing.T) {
 	b := &mockChromiumBrowser{
-		mockBrowser: mockBrowser{name: "Chrome", profile: "Default", userDataDir: "/p"},
+		mockBrowser: mockBrowser{name: chromeName, profile: testProfileDefault, userDataDir: testUDD},
 		keys:        keyretriever.MasterKeys{V10: []byte{0x01, 0x02, 0x03}, V20: []byte{0xff, 0xee}},
 	}
 
@@ -153,16 +160,16 @@ func TestBuildDump_JSONRoundTrip(t *testing.T) {
 	if parsed.Version != dump.Version {
 		t.Errorf("Version round-trip: got %q, want %q", parsed.Version, dump.Version)
 	}
-	if len(parsed.Installations) != 1 {
-		t.Fatalf("Installations len = %d", len(parsed.Installations))
+	if len(parsed.Vaults) != 1 {
+		t.Fatalf("Vaults len = %d", len(parsed.Vaults))
 	}
-	if !bytes.Equal(parsed.Installations[0].Keys.V10, dump.Installations[0].Keys.V10) {
+	if !bytes.Equal(parsed.Vaults[0].Keys.V10, dump.Vaults[0].Keys.V10) {
 		t.Errorf("V10 round-trip mismatch")
 	}
-	if !bytes.Equal(parsed.Installations[0].Keys.V20, dump.Installations[0].Keys.V20) {
+	if !bytes.Equal(parsed.Vaults[0].Keys.V20, dump.Vaults[0].Keys.V20) {
 		t.Errorf("V20 round-trip mismatch")
 	}
-	if parsed.Installations[0].Keys.V11 != nil {
-		t.Errorf("V11 should be omitted (nil), got %v", parsed.Installations[0].Keys.V11)
+	if parsed.Vaults[0].Keys.V11 != nil {
+		t.Errorf("V11 should be omitted (nil), got %v", parsed.Vaults[0].Keys.V11)
 	}
 }

--- a/browser/keydump_test.go
+++ b/browser/keydump_test.go
@@ -38,11 +38,13 @@ type mockChromiumBrowser struct {
 	mockBrowser
 	keys      keyretriever.MasterKeys
 	exportErr error
+	calls     int
 }
 
 func (m *mockChromiumBrowser) SetKeyRetrievers(_ keyretriever.Retrievers) {}
 
 func (m *mockChromiumBrowser) ExportKeys() (keyretriever.MasterKeys, error) {
+	m.calls++
 	return m.keys, m.exportErr
 }
 
@@ -171,5 +173,56 @@ func TestBuildDump_JSONRoundTrip(t *testing.T) {
 	}
 	if parsed.Vaults[0].Keys.V11 != nil {
 		t.Errorf("V11 should be omitted (nil), got %v", parsed.Vaults[0].Keys.V11)
+	}
+}
+
+func TestBuildDump_PartialKeys(t *testing.T) {
+	b := &mockChromiumBrowser{
+		mockBrowser: mockBrowser{name: chromeName, profile: testProfileDefault, userDataDir: testUDD},
+		keys:        keyretriever.MasterKeys{V10: []byte("v10")},
+		exportErr:   errors.New("v20: ABE failed"),
+	}
+
+	dump := BuildDump([]Browser{b})
+
+	if len(dump.Vaults) != 1 {
+		t.Fatalf("Vaults len = %d, want 1 (partial result must be preserved)", len(dump.Vaults))
+	}
+	if string(dump.Vaults[0].Keys.V10) != "v10" {
+		t.Errorf("V10 should be preserved despite V20 error, got %q", dump.Vaults[0].Keys.V10)
+	}
+	if dump.Vaults[0].Keys.V20 != nil {
+		t.Errorf("V20 should remain nil, got %v", dump.Vaults[0].Keys.V20)
+	}
+}
+
+func TestBuildDump_GroupingOrderIndependent(t *testing.T) {
+	for _, name := range []string{"p1 first", "p2 first"} {
+		t.Run(name, func(t *testing.T) {
+			p1 := &mockChromiumBrowser{
+				mockBrowser: mockBrowser{name: chromeName, profile: testProfileDefault, userDataDir: testUDD},
+				keys:        keyretriever.MasterKeys{V10: []byte("v10")},
+			}
+			p2 := &mockChromiumBrowser{
+				mockBrowser: mockBrowser{name: chromeName, profile: testProfile1, userDataDir: testUDD},
+				keys:        keyretriever.MasterKeys{V10: []byte("v10")},
+			}
+			list := []Browser{p1, p2}
+			if name == "p2 first" {
+				list = []Browser{p2, p1}
+			}
+
+			dump := BuildDump(list)
+
+			if len(dump.Vaults) != 1 {
+				t.Fatalf("Vaults len = %d, want 1", len(dump.Vaults))
+			}
+			if len(dump.Vaults[0].Profiles) != 2 {
+				t.Errorf("Profiles = %v, want 2", dump.Vaults[0].Profiles)
+			}
+			if calls := p1.calls + p2.calls; calls != 1 {
+				t.Errorf("ExportKeys total calls = %d, want 1 (one call per installation)", calls)
+			}
+		})
 	}
 }

--- a/browser/safari/safari.go
+++ b/browser/safari/safari.go
@@ -45,6 +45,7 @@ func resolveProfilePaths(p profileContext) map[types.Category]resolvedPath {
 
 func (b *Browser) BrowserName() string { return b.cfg.Name }
 func (b *Browser) ProfileName() string { return b.profile.name }
+func (b *Browser) UserDataDir() string { return b.cfg.UserDataDir }
 
 func (b *Browser) ProfileDir() string {
 	if b.profile.isDefault() {

--- a/cmd/hack-browser-data/keys.go
+++ b/cmd/hack-browser-data/keys.go
@@ -41,7 +41,7 @@ func keysExportCmd() *cobra.Command {
 			}
 
 			dump := browser.BuildDump(browsers)
-			log.Infof("Exported keys for %d installation(s)", len(dump.Installations))
+			log.Infof("Exported keys for %d vault(s)", len(dump.Vaults))
 
 			if outputPath == "" {
 				return dump.WriteJSON(os.Stdout)

--- a/cmd/hack-browser-data/keys.go
+++ b/cmd/hack-browser-data/keys.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/moond4rk/hackbrowserdata/browser"
+	"github.com/moond4rk/hackbrowserdata/log"
+)
+
+func keysCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "keys",
+		Short: "Manage cross-host master keys",
+	}
+	cmd.AddCommand(keysExportCmd())
+	return cmd
+}
+
+func keysExportCmd() *cobra.Command {
+	var (
+		browserName string
+		outputPath  string
+		keychainPw  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export Chromium master keys as JSON for cross-host decryption",
+		Example: `  hack-browser-data keys export -o dump.json
+  hack-browser-data keys export -b chrome`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			browsers, err := browser.PickBrowsers(browser.PickOptions{
+				Name:             browserName,
+				KeychainPassword: keychainPw,
+			})
+			if err != nil {
+				return err
+			}
+
+			dump := browser.BuildDump(browsers)
+			log.Infof("Exported keys for %d installation(s)", len(dump.Installations))
+
+			if outputPath == "" {
+				return dump.WriteJSON(os.Stdout)
+			}
+			f, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+			if err != nil {
+				return fmt.Errorf("create %s: %w", outputPath, err)
+			}
+			defer f.Close()
+			return dump.WriteJSON(f)
+		},
+	}
+
+	cmd.Flags().StringVarP(&browserName, "browser", "b", "all", "target browser: all|"+browser.Names())
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "output file (default: stdout)")
+	cmd.Flags().StringVar(&keychainPw, "keychain-pw", "", "macOS keychain password")
+
+	return cmd
+}

--- a/cmd/hack-browser-data/main.go
+++ b/cmd/hack-browser-data/main.go
@@ -31,7 +31,7 @@ GitHub: https://github.com/moonD4rk/HackBrowserData`,
 	root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable debug logging")
 
 	dump := dumpCmd()
-	root.AddCommand(dump, listCmd(), versionCmd())
+	root.AddCommand(dump, listCmd(), keysCmd(), versionCmd())
 
 	// Default to dump when no subcommand is given.
 	// Copy dump flags to root so that `hack-browser-data -b chrome`

--- a/crypto/keyretriever/dump.go
+++ b/crypto/keyretriever/dump.go
@@ -1,0 +1,90 @@
+package keyretriever
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"runtime"
+	"time"
+)
+
+const DumpVersion = "1"
+
+// Dump is the cross-host portable container for Chromium-family master keys.
+// A Dump produced on one host can be consumed on another to skip platform-native
+// key retrieval (DPAPI, ABE injection, Keychain prompt, D-Bus query) when
+// decrypting a copy of the browser's profile data.
+type Dump struct {
+	Version       string         `json:"version"`
+	GeneratedAt   time.Time      `json:"generated_at"`
+	Host          DumpHost       `json:"host"`
+	Installations []Installation `json:"installations"`
+}
+
+// DumpHost OS / Arch always set; Hostname / User best-effort (empty on syscall failure).
+type DumpHost struct {
+	OS       string `json:"os"`
+	Arch     string `json:"arch"`
+	Hostname string `json:"hostname,omitempty"`
+	User     string `json:"user,omitempty"`
+}
+
+// Installation groups profiles sharing master keys (master keys are per-installation, not per-profile).
+type Installation struct {
+	Browser     string      `json:"browser"`
+	UserDataDir string      `json:"user_data_dir"`
+	Profiles    []string    `json:"profiles"`
+	Keys        InstallKeys `json:"keys"`
+}
+
+// InstallKeys per-cipher-tier master keys; encoding/json marshals []byte as base64.
+type InstallKeys struct {
+	V10 []byte `json:"v10,omitempty"`
+	V11 []byte `json:"v11,omitempty"`
+	V20 []byte `json:"v20,omitempty"`
+}
+
+// NewDump returns a Dump initialized with current host metadata and an empty Installations slice
+func NewDump() Dump {
+	return Dump{
+		Version:       DumpVersion,
+		GeneratedAt:   time.Now().UTC(),
+		Host:          currentHost(),
+		Installations: []Installation{},
+	}
+}
+
+// currentHost collects host identification. Hostname / User are best-effort:
+// syscall failures leave the field empty, omitted from JSON via `omitempty`.
+func currentHost() DumpHost {
+	h := DumpHost{OS: runtime.GOOS, Arch: runtime.GOARCH}
+	if name, err := os.Hostname(); err == nil {
+		h.Hostname = name
+	}
+	if u, err := user.Current(); err == nil {
+		h.User = u.Username
+	}
+	return h
+}
+
+// WriteJSON writes the Dump as indented JSON to w.
+func (d Dump) WriteJSON(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(d); err != nil {
+		return fmt.Errorf("encode dump: %w", err)
+	}
+	return nil
+}
+
+// ReadJSON parses a Dump from r.
+func ReadJSON(r io.Reader) (Dump, error) {
+	var d Dump
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&d); err != nil {
+		return Dump{}, fmt.Errorf("decode dump: %w", err)
+	}
+	return d, nil
+}

--- a/crypto/keyretriever/dump.go
+++ b/crypto/keyretriever/dump.go
@@ -12,54 +12,44 @@ import (
 
 const DumpVersion = "1"
 
-// Dump is the cross-host portable container for Chromium-family master keys.
-// A Dump produced on one host can be consumed on another to skip platform-native
-// key retrieval (DPAPI, ABE injection, Keychain prompt, D-Bus query) when
-// decrypting a copy of the browser's profile data.
+// Dump is the cross-host portable container for Chromium master keys. Producing it on one host lets another host skip
+// platform-native retrieval (DPAPI, ABE injection, Keychain prompt, D-Bus query) when decrypting copied profile data.
 type Dump struct {
-	Version       string         `json:"version"`
-	GeneratedAt   time.Time      `json:"generated_at"`
-	Host          DumpHost       `json:"host"`
-	Installations []Installation `json:"installations"`
+	Version   string    `json:"version"`
+	CreatedAt time.Time `json:"created_at"`
+	Host      Host      `json:"host"`
+	Vaults    []Vault   `json:"vaults"`
 }
 
-// DumpHost OS / Arch always set; Hostname / User best-effort (empty on syscall failure).
-type DumpHost struct {
+// Host OS / Arch always set; Hostname / User best-effort (empty on syscall failure).
+type Host struct {
 	OS       string `json:"os"`
 	Arch     string `json:"arch"`
 	Hostname string `json:"hostname,omitempty"`
 	User     string `json:"user,omitempty"`
 }
 
-// Installation groups profiles sharing master keys (master keys are per-installation, not per-profile).
-type Installation struct {
-	Browser     string      `json:"browser"`
-	UserDataDir string      `json:"user_data_dir"`
-	Profiles    []string    `json:"profiles"`
-	Keys        InstallKeys `json:"keys"`
+// Vault groups profiles sharing master keys (master keys are per-installation, not per-profile).
+type Vault struct {
+	Browser     string     `json:"browser"`
+	UserDataDir string     `json:"user_data_dir"`
+	Profiles    []string   `json:"profiles"`
+	Keys        MasterKeys `json:"keys"`
 }
 
-// InstallKeys per-cipher-tier master keys; encoding/json marshals []byte as base64.
-type InstallKeys struct {
-	V10 []byte `json:"v10,omitempty"`
-	V11 []byte `json:"v11,omitempty"`
-	V20 []byte `json:"v20,omitempty"`
-}
-
-// NewDump returns a Dump initialized with current host metadata and an empty Installations slice
+// NewDump returns a Dump initialized with current host metadata and an empty Vaults slice
 func NewDump() Dump {
 	return Dump{
-		Version:       DumpVersion,
-		GeneratedAt:   time.Now().UTC(),
-		Host:          currentHost(),
-		Installations: []Installation{},
+		Version:   DumpVersion,
+		CreatedAt: time.Now().UTC(),
+		Host:      currentHost(),
+		Vaults:    []Vault{},
 	}
 }
 
-// currentHost collects host identification. Hostname / User are best-effort:
-// syscall failures leave the field empty, omitted from JSON via `omitempty`.
-func currentHost() DumpHost {
-	h := DumpHost{OS: runtime.GOOS, Arch: runtime.GOARCH}
+// currentHost collects host identification; Hostname/User are best-effort (syscall failure leaves them empty + omitempty).
+func currentHost() Host {
+	h := Host{OS: runtime.GOOS, Arch: runtime.GOARCH}
 	if name, err := os.Hostname(); err == nil {
 		h.Hostname = name
 	}

--- a/crypto/keyretriever/masterkeys.go
+++ b/crypto/keyretriever/masterkeys.go
@@ -14,6 +14,12 @@ type MasterKeys struct {
 	V20 []byte `json:"v20,omitempty"`
 }
 
+// HasAny reports whether at least one tier carries a usable key. Centralizes the "is this MasterKeys
+// worth keeping" check so new tiers (V21, V12, …) only need to be added here, not at every caller.
+func (k MasterKeys) HasAny() bool {
+	return k.V10 != nil || k.V11 != nil || k.V20 != nil
+}
+
 // Retrievers is the per-tier retriever configuration; unused slots are nil.
 type Retrievers struct {
 	V10 KeyRetriever

--- a/crypto/keyretriever/masterkeys.go
+++ b/crypto/keyretriever/masterkeys.go
@@ -9,9 +9,9 @@ import (
 // (Chrome 127+ on Windows mixes v10+v20; Linux can mix v10+v11), so each tier must be populated
 // independently for lossless decryption. A nil tier means that cipher version cannot be decrypted.
 type MasterKeys struct {
-	V10 []byte
-	V11 []byte
-	V20 []byte
+	V10 []byte `json:"v10,omitempty"`
+	V11 []byte `json:"v11,omitempty"`
+	V20 []byte `json:"v20,omitempty"`
 }
 
 // Retrievers is the per-tier retriever configuration; unused slots are nil.


### PR DESCRIPTION
## Summary
- New `keys export` subcommand serializes Chromium master keys as JSON for offline / cross-host decryption.
- Library API: `browser.BuildDump([]Browser) keyretriever.Dump`; `KeyManager.ExportKeys()` capability on chromium engine.
- Firefox / Safari are skipped — their master keys are not portable across hosts.

## Test plan
- [x] `go vet` / `go test` / cross-compile darwin·linux·windows / `gofumpt` + `goimports` all clean
- [x] macOS e2e: Chrome 1 installation, 10 profiles, V10 = 16B
- [x] Windows sandbox e2e: 12 installations; ABE V10+V20 (32B each) for Chrome / Edge / CocCoc / Brave; DPAPI V10 (32B) for Opera / OperaGX / Vivaldi / Yandex / 360 / QQ / Sogou / Arc
- [x] `host` metadata correctly populated on both platforms (`os`, `arch`, `hostname`, `user`)