### PR TITLE
ci: unify bot automation on the shared GitHub App

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -18,8 +18,8 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.HACKBROWSERDATA_BOT_APP_ID }}
-          private-key: ${{ secrets.HACKBROWSERDATA_BOT_PRIVATE_KEY }}
+          client-id: ${{ vars.MOOND4RK_CI_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MOOND4RK_CI_RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Mint homebrew-tap token
         id: tap-token
+        if: inputs.mode == 'release'
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.MOOND4RK_CI_RELEASE_APP_CLIENT_ID }}
@@ -84,7 +85,6 @@ jobs:
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap-token.outputs.token }}
 
       - name: Run GoReleaser (release)
         if: inputs.mode == 'release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,15 @@ jobs:
       - name: Build ABE payload
         run: make payload
 
+      - name: Mint homebrew-tap token
+        id: tap-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.MOOND4RK_CI_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MOOND4RK_CI_RELEASE_APP_PRIVATE_KEY }}
+          owner: moonD4rk
+          repositories: homebrew-tap
+
       - name: Create and push tag
         if: inputs.mode == 'release'
         env:
@@ -75,7 +84,7 @@ jobs:
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap-token.outputs.token }}
 
       - name: Run GoReleaser (release)
         if: inputs.mode == 'release'
@@ -85,7 +94,7 @@ jobs:
           args: release --clean ${{ inputs.draft && '--draft' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.tap-token.outputs.token }}
 
       - name: Upload snapshot artifacts
         if: inputs.mode == 'snapshot'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -101,8 +101,8 @@ brews:
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     commit_author:
-      name: "github-actions[bot]"
-      email: "github-actions[bot]@users.noreply.github.com"
+      name: "moond4rk-ci[bot]"
+      email: "299850723+moond4rk-ci[bot]@users.noreply.github.com"
     commit_msg_template: "brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     install: |
       bin.install "hack-browser-data"


### PR DESCRIPTION
Unify bot automation in this repo on the shared GitHub App.

**contributors.yml** — point at the shared app via `client-id` (was the old `hackbrowserdata-bot` app / deprecated `app-id`).

**release.yml + .goreleaser.yml** — replace the long-lived Homebrew PAT with a short-lived app token scoped to `homebrew-tap`:
- mint it via `create-github-app-token`, hand it to GoReleaser as `HOMEBREW_TAP_GITHUB_TOKEN` (was `secrets.HOMEBREW_TAP_GITHUB_TOKEN`);
- attribute the formula-bump commit to the app instead of `github-actions[bot]`.

The in-repo tag, GitHub Release, and snapshot builds still use the default `GITHUB_TOKEN`. Requires the app installed on this repo (contributors) and on `homebrew-tap` (formula push).