### PR TITLE
feat: add support for Browser from Vought

### DIFF
--- a/browser/browser_windows.go
+++ b/browser/browser_windows.go
@@ -50,7 +50,7 @@ func platformBrowsers() []types.BrowserConfig {
 		},
 		{
 			Key:         "vought",
-			Name:        browserFromVoughtName,
+			Name:        voughtName,
 			Kind:        types.ChromiumOpera,
 			UserDataDir: homeDir + "/AppData/Roaming/Browser from Vought",
 		},

--- a/browser/browser_windows.go
+++ b/browser/browser_windows.go
@@ -49,6 +49,12 @@ func platformBrowsers() []types.BrowserConfig {
 			UserDataDir: homeDir + "/AppData/Roaming/Opera Software/Opera GX Stable",
 		},
 		{
+			Key:         "vought",
+			Name:        browserFromVoughtName,
+			Kind:        types.ChromiumOpera,
+			UserDataDir: homeDir + "/AppData/Roaming/Browser from Vought",
+		},
+		{
 			Key:         "vivaldi",
 			Name:        vivaldiName,
 			Kind:        types.Chromium,

--- a/browser/consts.go
+++ b/browser/consts.go
@@ -15,6 +15,7 @@ const (
 	braveName      = "Brave"
 	operaName      = "Opera"
 	operaGXName    = "OperaGX"
+	voughtName     = "Browser from Vought"
 	vivaldiName    = "Vivaldi"
 	coccocName     = "CocCoc"
 	yandexName     = "Yandex"


### PR DESCRIPTION
## Summary

Fixes #620 by adding the definition for 'Browser from Vought' to `browser/browser_windows.go` and `browser/consts.go`.

## Checklist

- [x] Pull request targets the `main` branch
- [x] All CI checks pass (lint, test, build)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] go.mod directive remains `go 1.20` (do not bump)
