### PR TITLE
ci: open a PR for contributor updates instead of pushing to main

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -34,5 +34,6 @@ jobs:
           image_size: 100
           columns_per_row: 6
           readme_path: README.md
-          auto_detect_branch_protection: false
-          commit_message: 'chore: update contributors list [skip ci]'
+          auto_detect_branch_protection: true
+          commit_message: 'chore: update contributors list'
+          pr_title_on_protected: 'chore: update contributors list'


### PR DESCRIPTION
## Summary

The Contributors workflow has been failing since #619 switched it to the shared GitHub App: the app is not in the `main` ruleset's bypass list, so its direct push to `main` is rejected with `Repository rule violations found`. The failure only surfaced now because every run since the switch had no contributor diff to push — merging #622 added one.

This switches the action to its protected-branch path (`auto_detect_branch_protection: true`), where it creates a temporary branch and opens a PR instead of pushing. Verified against `contributors-readme-action` v2.3.11:

- Detection reads `GET /repos/{owner}/{repo}/branches/main` → `protected`, which is `true` here even though the repo has no classic branch protection (protection comes from rulesets), so the PR path is taken.
- The skip-ci marker is dropped from `commit_message`. It would land on the HEAD commit of the generated PR and skip the `pull_request`-triggered workflows, leaving the 9 required status checks unreported and the PR permanently unmergeable.
- `pr_title_on_protected` is set explicitly so the squashed commit keeps the repo's conventional-commit style — the default title is `docs(contributor): contributors readme action update`, and squash merges here use `COMMIT_OR_PR_TITLE`.
- Required checks still report on the generated PR: `build`, `test` and `lint` all trigger on `pull_request` with no path filter, and the app installation token (unlike `GITHUB_TOKEN`) does trigger workflow runs.

The PR and its commit will be authored by `moond4rk-ci[bot]`. Temporary `contributors-readme-action-*` branches are cleaned up automatically since `delete_branch_on_merge` is enabled.

The alternative — adding the shared app to the ruleset's bypass list — is left out deliberately; this keeps `main` writable only through PRs.

Note for anyone editing this branch: the skip marker must not appear literally anywhere in a commit message, body included. GitHub scans the whole message, not just the subject line, and silently skips every `push`/`pull_request` workflow.

## Checklist

- [x] Pull request targets the `main` branch
- [x] All CI checks pass (lint, test, build)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A, workflow configuration only
- [ ] I have added necessary documentation (if appropriate) — N/A
- [x] go.mod directive remains `go 1.20` (do not bump)

https://claude.ai/code/session_011GzPywfeNAx2BVA2M6RnuH