### PR TITLE
ci: auto-merge the generated contributors PR

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -27,6 +27,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Update contributors list
+        id: contributors
         uses: akhilmhdh/contributors-readme-action@v2.3.11
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -37,3 +38,11 @@ jobs:
           auto_detect_branch_protection: true
           commit_message: 'chore: update contributors list'
           pr_title_on_protected: 'chore: update contributors list'
+
+      - name: Enable auto-merge
+        if: steps.contributors.outputs.pr_id != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ steps.contributors.outputs.pr_id }}
+          REPO: ${{ github.repository }}
+        run: gh pr merge "$PR" --squash --auto -R "$REPO"


### PR DESCRIPTION
## Summary

#626 is the first PR the Contributors workflow generated after #625, and it shows the one gap left: 9 checks green, no conflicts, and it still waits for a human to click **Squash and merge**.

This enables auto-merge on the generated PR via the `pr_id` output the action already exposes.

- Preconditions hold: the repo has `allow_auto_merge: true`, and the `main` ruleset sets `required_approving_review_count: 0`, so the PR merges the moment the 9 required checks pass.
- Guarded by `if: steps.contributors.outputs.pr_id != ''` — the action only sets that output when the branch is protected *and* the README actually changed, so no-op runs skip the step.
- Same app installation token as the action; #626 already proved it has `pull-requests: write`.
- Auto-merge rather than an outright merge keeps the gate intact: the 9 required checks still have to pass, and `strict_required_status_checks_policy` still forces the branch to be up to date first.
- Values go through `env:` instead of being interpolated into `run:`, matching the pattern already used in `release.yml`.

Beyond removing the manual click, this closes a duplicate-PR failure mode: the action mints a fresh `contributors-readme-action-*` branch and a brand-new PR on every run with no dedup check, so an unmerged bot PR accumulates a sibling on each subsequent push to `main`.

**Merge order matters** — merge #626 first, then this PR. The other way round, this PR's own merge commit triggers Contributors while the README is still stale, opening a second contributors PR alongside #626.

## Checklist

- [x] Pull request targets the `main` branch
- [x] All CI checks pass (lint, test, build)
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A, workflow configuration only
- [ ] I have added necessary documentation (if appropriate) — N/A
- [x] go.mod directive remains `go 1.20` (do not bump)

https://claude.ai/code/session_01X6RUAuQYzireYCp9DTdtSm
