### PR TITLE
refactor(darwin): gate securityd gcore keychain dump behind keychain_gcore build tag

### DIFF
--- a/masterkey/gcoredump_darwin.go
+++ b/masterkey/gcoredump_darwin.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build darwin && keychain_gcore
 
 package masterkey
 

--- a/masterkey/gcoredump_stub_darwin.go
+++ b/masterkey/gcoredump_stub_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin && !keychain_gcore
+
+package masterkey
+
+import (
+	"errors"
+
+	"github.com/moond4rk/keychainbreaker"
+)
+
+// DecryptKeychainRecords returns an error in default builds so GcoredumpRetriever
+// falls through silently to the next tier. The CVE-2025-24204 securityd-dump
+// implementation (gcoredump_darwin.go) is only compiled with -tags keychain_gcore,
+// keeping the default `go build` free of the exploit code and its byte signatures.
+func DecryptKeychainRecords() ([]keychainbreaker.GenericPassword, error) {
+	return nil, errors.New("keychain gcore dump not built in (rebuild with -tags keychain_gcore)")
+}


### PR DESCRIPTION
## Summary

Mirrors the `abe_embed` treatment of the Windows ABE payload (#575) for the macOS
CVE-2025-24204 securityd-dump path, so the sensitive code is opt-in at build time
instead of always compiled into every darwin binary.

- Retag `masterkey/gcoredump_darwin.go` from `//go:build darwin` to
  `//go:build darwin && keychain_gcore`. All of the gcore/`vmmap`/Mach-O scanning
  code, plus its helpers (`findProcessByName`, `scanMasterKeyCandidates`,
  `findMallocSmallRegions`, `getMallocSmallRegionData`, `addressRange`,
  `byteSliceToString`, `homeDir`/`loginKeychainPath`) is used only in this file,
  so it moves under the tag cleanly.
- Add `masterkey/gcoredump_stub_darwin.go` (`//go:build darwin && !keychain_gcore`)
  providing `DecryptKeychainRecords()` that returns an error — same stub/real split
  as `crypto/windows/payload/{stub,embed}_windows.go`.

`GcoredumpRetriever` (struct + `RetrieveKey`) stays unconditional in
`retriever_darwin.go`; its single caller of `DecryptKeychainRecords()` already treats
any error as a silent fallthrough to the next tier (the "needs root" case), so the
default build just falls through to `KeychainPasswordRetriever` /
`SecurityCmdRetriever` exactly as a non-root run does today. No behavior change for
the native-Keychain path.

### Why

The securityd-dump code (byte-scanning `securityd` memory via a `gcore` core dump)
is the part of the darwin build that gets flagged in security audits and antivirus
scans (cf. the recurring reports #623, #497, #469). It only helps a `root` caller,
which is a rare path. Making it opt-in via `-tags keychain_gcore` means the default
`go build ./...` — and anything importing HackBrowserData as a library — ships
without the exploit code or its identifying strings, while release/CLI users who want
it opt in exactly like `-tags abe_embed`.

### Note for release builds

This PR is the mechanism only (as #575 was for the payload; #590 wired the release
tag separately). The darwin binary in `.goreleaser.yml` (`id: hack-browser-data`)
carries no tags, so with this change official darwin releases would be gcore-off by
default. If you want release parity with today, add `tags: [keychain_gcore]` to that
build (or a dedicated darwin build id) — happy to fold that in here or leave it to a
follow-up, your call on release policy.

## Test plan

- [x] `go build ./...` (darwin, default) — no securityd/gcore code linked
- [x] `go build -tags keychain_gcore ./...` (darwin)
- [x] `GOOS=linux GOARCH=amd64 go build ./...`
- [x] `GOOS=windows GOARCH=amd64 go build ./...`
- [x] `go vet ./masterkey/...` default + `-tags keychain_gcore`
- [x] `go test ./masterkey/...` default + `-tags keychain_gcore` — pass
- [x] Signature check on the built CLI: default binary has `0` matches for
      `securityd`, `kern.proc.all`, `MALLOC_SMALL`, `scanMasterKeyCandidates`,
      `findMallocSmallRegions`; the `-tags keychain_gcore` binary has all of them.
- [ ] `golangci-lint run` / `typos` — not run locally; deferring to CI.
